### PR TITLE
CI

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -36,10 +36,10 @@ jobs:
           - ubuntu-latest
           # Use windows-2019 due to:
           # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-          - windows-2019
+          #- windows-2019
           # We're using a specific version of macOS due to:
           # https://github.com/actions/virtual-environments/issues/5900
-          - macOS-11
+          #- macOS-11
     steps:
       - name: Setup Windows
         if: startsWith(matrix.os, 'windows')
@@ -82,8 +82,8 @@ jobs:
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         with:
-          cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
-          build_target:  '${{ inputs.build_target }}'
+          cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
+          build_target: '${{ inputs.build_target }}'
 
       - name: Build and Test libclc
         if: "!startsWith(matrix.os, 'windows') && contains(inputs.projects, 'libclc')"

--- a/.github/workflows/mlir-tests.yml
+++ b/.github/workflows/mlir-tests.yml
@@ -5,12 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  push:
-    ignore-forks: true
-    paths:
-      - 'mlir/**'
-      - '.github/workflows/mlir-tests.yml'
-      - '.github/workflows/llvm-project-tests.yml'
   pull_request:
     ignore-forks: true
     paths:

--- a/.github/workflows/mlir-tests.yml
+++ b/.github/workflows/mlir-tests.yml
@@ -1,0 +1,33 @@
+name: MLIR Tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    ignore-forks: true
+    paths:
+      - 'mlir/**'
+      - '.github/workflows/mlir-tests.yml'
+      - '.github/workflows/llvm-project-tests.yml'
+  pull_request:
+    ignore-forks: true
+    paths:
+      - 'mlir/**'
+      - '.github/workflows/mlir-tests.yml'
+      - '.github/workflows/llvm-project-tests.yml'
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  check_mlir:
+    name: Test mlir
+    uses: ./.github/workflows/llvm-project-tests.yml
+    with:
+      build_target: check-mlir
+      projects: mlir


### PR DESCRIPTION
Enable CI to run `check-mlir` for changes in `mlir/**`.
Disable Windows/MacOS to use less of the public runners capacity.