### PR TITLE
FXML.1923: PDLL support for native constraints with attribute results

### DIFF
--- a/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
@@ -35,7 +35,7 @@ def PDL_ApplyNativeConstraintOp
   let description = [{
     `pdl.apply_native_constraint` operations apply a native C++ constraint, that
     has been registered externally with the consumer of PDL, to a given set of
-    entities.
+    entities and optionally return a number of values..
 
     Example:
 
@@ -46,7 +46,8 @@ def PDL_ApplyNativeConstraintOp
   }];
 
   let arguments = (ins StrAttr:$name, Variadic<PDL_AnyType>:$args);
-  let assemblyFormat = "$name `(` $args `:` type($args) `)` attr-dict";
+  let results = (outs Variadic<PDL_AnyType>:$results);
+  let assemblyFormat = "$name `(` $args `:` type($args) `)` (`->` `(` type($results)^ `)`)? attr-dict";
   let hasVerifier = 1;
 }
 

--- a/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
@@ -47,7 +47,7 @@ def PDL_ApplyNativeConstraintOp
 
   let arguments = (ins StrAttr:$name, Variadic<PDL_AnyType>:$args);
   let results = (outs Variadic<PDL_AnyType>:$results);
-  let assemblyFormat = "$name `(` $args `:` type($args) `)` (`->` `(` type($results)^ `)`)? attr-dict";
+  let assemblyFormat = "$name `(` $args `:` type($args) `)` (`:`  type($results)^ )? attr-dict";
   let hasVerifier = 1;
 }
 

--- a/mlir/include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td
+++ b/mlir/include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td
@@ -88,8 +88,9 @@ def PDLInterp_ApplyConstraintOp : PDLInterp_PredicateOp<"apply_constraint"> {
   let description = [{
     `pdl_interp.apply_constraint` operations apply a generic constraint, that
     has been registered with the interpreter, with a given set of positional
-    values. On success, this operation branches to the true destination,
-    otherwise the false destination is taken.
+    values.  The constraint function may return any number of results. 
+    On success, this operation branches to the true destination, otherwise
+    the false destination is taken.
 
     Example:
 
@@ -101,8 +102,9 @@ def PDLInterp_ApplyConstraintOp : PDLInterp_PredicateOp<"apply_constraint"> {
   }];
 
   let arguments = (ins StrAttr:$name, Variadic<PDL_AnyType>:$args);
+  let results = (outs Variadic<PDL_AnyType>:$results);
   let assemblyFormat = [{
-    $name `(` $args `:` type($args) `)` attr-dict `->` successors
+    $name `(` $args `:` type($args) `)` (`:` type($results)^)? attr-dict `->` successors
   }];
 }
 

--- a/mlir/include/mlir/IR/PatternMatch.h
+++ b/mlir/include/mlir/IR/PatternMatch.h
@@ -1457,6 +1457,33 @@ public:
                                    std::forward<ConstraintFnT>(constraintFn)));
   }
 
+  /// Register a constraint function that produces results with PDL. A
+  /// constraint function with results uses the same type and registry as
+  /// rewrite functions. It may be specified in one of two ways:
+  ///
+  ///   * `void (PatternRewriter &, PDLResultList &, ArrayRef<PDLValue>)`
+  ///
+  ///   In this overload the arguments of the constraint function are passed via
+  ///   the low-level PDLValue form, and the results are manually appended to
+  ///   the given result list.
+  ///
+  ///   * `ResultT (PatternRewriter &, ValueTs... values)`
+  ///
+  ///   In this form the arguments and result of the constraint function are
+  ///   passed via the expected high level C++ type. In this form, the framework
+  ///   will automatically unwrap the PDLValues arguments and convert them to
+  ///   the expected ValueTs. It will also automatically handle the processing
+  ///   and packaging of the result value to the result list. For more
+  ///   information see the registering of rewrite functions below.
+  void registerConstraintFunctionWithResults(StringRef name,
+                                             PDLRewriteFunction constraintFn);
+  template <typename RewriteFnT>
+  void registerConstraintFunctionWithResults(StringRef name,
+                                             RewriteFnT &&constraintFn) {
+    registerRewriteFunction(name, detail::pdl_function_builder::buildRewriteFn(
+                                      std::forward<RewriteFnT>(constraintFn)));
+  }
+
   /// Register a rewrite function with PDL. A rewrite function may be specified
   /// in one of two ways:
   ///

--- a/mlir/include/mlir/IR/PatternMatch.h
+++ b/mlir/include/mlir/IR/PatternMatch.h
@@ -1459,30 +1459,17 @@ public:
 
   /// Register a constraint function that produces results with PDL. A
   /// constraint function with results uses the same type and registry as
-  /// rewrite functions. It may be specified in one of two ways:
+  /// rewrite functions. It may be specified as follows:
   ///
-  ///   * `void (PatternRewriter &, PDLResultList &, ArrayRef<PDLValue>)`
+  ///   * `LogicalResult (PatternRewriter &, PDLResultList &,
+  ///   ArrayRef<PDLValue>)`
   ///
   ///   In this overload the arguments of the constraint function are passed via
   ///   the low-level PDLValue form, and the results are manually appended to
   ///   the given result list.
   ///
-  ///   * `ResultT (PatternRewriter &, ValueTs... values)`
-  ///
-  ///   In this form the arguments and result of the constraint function are
-  ///   passed via the expected high level C++ type. In this form, the framework
-  ///   will automatically unwrap the PDLValues arguments and convert them to
-  ///   the expected ValueTs. It will also automatically handle the processing
-  ///   and packaging of the result value to the result list. For more
-  ///   information see the registering of rewrite functions below.
   void registerConstraintFunctionWithResults(StringRef name,
                                              PDLRewriteFunction constraintFn);
-  template <typename RewriteFnT>
-  void registerConstraintFunctionWithResults(StringRef name,
-                                             RewriteFnT &&constraintFn) {
-    registerRewriteFunction(name, detail::pdl_function_builder::buildRewriteFn(
-                                      std::forward<RewriteFnT>(constraintFn)));
-  }
 
   /// Register a rewrite function with PDL. A rewrite function may be specified
   /// in one of two ways:

--- a/mlir/include/mlir/IR/PatternMatch.h
+++ b/mlir/include/mlir/IR/PatternMatch.h
@@ -1458,7 +1458,7 @@ public:
   }
 
   /// Register a constraint function that produces results with PDL. A
-  /// constraint function with results uses the same type and registry as
+  /// constraint function with results uses the same registry as
   /// rewrite functions. It may be specified as follows:
   ///
   ///   * `LogicalResult (PatternRewriter &, PDLResultList &,

--- a/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
@@ -473,11 +473,12 @@ void PatternLowering::generate(BoolNode *boolNode, Block *&currentBlock,
     for (auto result : llvm::enumerate(applyConstraintOp.getResults())) {
       std::pair<ConstraintQuestion *, unsigned> substitutionKey = {
           cstQuestion, result.index()};
-      assert(
-          substitutions.count(substitutionKey) &&
-          "expected a placeholder value for a native constraint with results");
-      substitutions[substitutionKey].replaceAllUsesWith(result.value());
-      substitutions[substitutionKey].getDefiningOp()->erase();
+      // Check if there are substitutions to perform. If the result is never
+      // used no substitutions will have been generated.
+      if (substitutions.count(substitutionKey)) {
+        substitutions[substitutionKey].replaceAllUsesWith(result.value());
+        substitutions[substitutionKey].getDefiningOp()->erase();
+      }
     }
     break;
   }

--- a/mlir/lib/Conversion/PDLToPDLInterp/PredicateTree.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PredicateTree.cpp
@@ -272,8 +272,16 @@ static void getConstraintPredicates(pdl::ApplyNativeConstraintOp op,
   // Push the constraint to the furthest position.
   Position *pos = *std::max_element(allPositions.begin(), allPositions.end(),
                                     comparePosDepth);
-  PredicateBuilder::Predicate pred =
-      builder.getConstraint(op.getName(), allPositions);
+  ResultRange results = op.getResults();
+  PredicateBuilder::Predicate pred = builder.getConstraint(
+      op.getName(), allPositions, SmallVector<Type>(results.getTypes()));
+
+  // for each result register a position so it can be used later
+  for (auto result : llvm::enumerate(results)) {
+    ConstraintQuestion *q = cast<ConstraintQuestion>(pred.first);
+    ConstraintPosition *pos = builder.getConstraintPosition(q, result.index());
+    inputs[result.value()] = pos;
+  }
   predList.emplace_back(pos, pred);
 }
 

--- a/mlir/lib/IR/PatternMatch.cpp
+++ b/mlir/lib/IR/PatternMatch.cpp
@@ -204,6 +204,15 @@ void PDLPatternModule::registerConstraintFunction(
   constraintFunctions.try_emplace(name, std::move(constraintFn));
 }
 
+void PDLPatternModule::registerConstraintFunctionWithResults(
+    StringRef name, PDLRewriteFunction constraintFn) {
+  // TODO: Is it possible to diagnose when `name` is already registered to
+  // a function that is not equivalent to `rewriteFn`?
+  // Allow existing mappings in the case multiple patterns depend on the same
+  // rewrite.
+  registerRewriteFunction(name, std::move(constraintFn));
+}
+
 void PDLPatternModule::registerRewriteFunction(StringRef name,
                                                PDLRewriteFunction rewriteFn) {
   // TODO: Is it possible to diagnose when `name` is already registered to

--- a/mlir/lib/Rewrite/ByteCode.cpp
+++ b/mlir/lib/Rewrite/ByteCode.cpp
@@ -781,7 +781,8 @@ void Generator::generate(pdl_interp::ApplyConstraintOp op,
   } else {
     assert(true && "expected index for constraint function, make sure it is "
                    "registered properly. Note that native constraints with "
-                   "results have to be registered as native rewriters.");
+                   "results have to be registered using "
+                   "PDLPatternModule::registerConstraintFunctionWithResults.");
   }
   writer.appendPDLValueList(op.getArgs());
   writer.append(ByteCodeField(results.size()));

--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -1356,12 +1356,6 @@ FailureOr<T *> Parser::parseUserNativeConstraintOrRewriteDecl(
   if (failed(parseToken(Token::semicolon,
                         "expected `;` after native declaration")))
     return failure();
-  // TODO: PDL should be able to support constraint results in certain
-  // situations, we should revise this.
-  if (std::is_same<ast::UserConstraintDecl, T>::value && !results.empty()) {
-    return emitError(
-        "native Constraints currently do not support returning results");
-  }
   return T::createNative(ctx, name, arguments, results, optCodeStr, resultType);
 }
 

--- a/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
+++ b/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
@@ -93,6 +93,20 @@ module @constraint_with_result {
 
 // -----
 
+// CHECK-LABEL: module @constraint_with_unused_result
+module @constraint_with_unused_result {
+  // CHECK: func @matcher(%[[ROOT:.*]]: !pdl.operation)
+  // CHECK: %[[ATTR:.*]] = pdl_interp.apply_constraint "check_op_and_get_attr_constr"(%[[ROOT]]
+  // CHECK: pdl_interp.record_match @rewriters::@pdl_generated_rewriter(%[[ROOT]] : !pdl.operation)
+  pdl.pattern : benefit(1) {
+    %root = operation
+    %attr = pdl.apply_native_constraint "check_op_and_get_attr_constr"(%root : !pdl.operation) : !pdl.attribute
+    rewrite %root with "rewriter"
+  }
+}
+
+// -----
+
 // CHECK-LABEL: module @inputs
 module @inputs {
   // CHECK: func @matcher(%[[ROOT:.*]]: !pdl.operation)

--- a/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
+++ b/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
@@ -79,6 +79,20 @@ module @constraints {
 
 // -----
 
+// CHECK-LABEL: module @constraint_with_result
+module @constraint_with_result {
+  // CHECK: func @matcher(%[[ROOT:.*]]: !pdl.operation)
+  // CHECK: %[[ATTR:.*]] = pdl_interp.apply_constraint "check_op_and_get_attr_constr"(%[[ROOT]]
+  // CHECK: pdl_interp.record_match @rewriters::@pdl_generated_rewriter(%[[ROOT]], %[[ATTR]] : !pdl.operation, !pdl.attribute)
+  pdl.pattern : benefit(1) {
+    %root = operation
+    %attr = pdl.apply_native_constraint "check_op_and_get_attr_constr"(%root : !pdl.operation) : !pdl.attribute
+    rewrite %root with "rewriter"(%attr : !pdl.attribute)
+  }
+}
+
+// -----
+
 // CHECK-LABEL: module @inputs
 module @inputs {
   // CHECK: func @matcher(%[[ROOT:.*]]: !pdl.operation)

--- a/mlir/test/Dialect/PDL/ops.mlir
+++ b/mlir/test/Dialect/PDL/ops.mlir
@@ -144,7 +144,7 @@ pdl.pattern @apply_constraint_with_no_results : benefit(1) {
 
 pdl.pattern @apply_constraint_with_results : benefit(1) {
   %root = operation
-  %attr = apply_native_constraint "NativeConstraint"(%root : !pdl.operation) -> (!pdl.attribute)
+  %attr = apply_native_constraint "NativeConstraint"(%root : !pdl.operation) : !pdl.attribute
   rewrite %root {
     apply_native_rewrite "NativeRewrite"(%attr : !pdl.attribute)
   }

--- a/mlir/test/Dialect/PDL/ops.mlir
+++ b/mlir/test/Dialect/PDL/ops.mlir
@@ -134,6 +134,24 @@ pdl.pattern @apply_rewrite_with_no_results : benefit(1) {
 
 // -----
 
+pdl.pattern @apply_constraint_with_no_results : benefit(1) {
+  %root = operation
+  apply_native_constraint "NativeConstraint"(%root : !pdl.operation)
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+pdl.pattern @apply_constraint_with_results : benefit(1) {
+  %root = operation
+  %attr = apply_native_constraint "NativeConstraint"(%root : !pdl.operation) -> (!pdl.attribute)
+  rewrite %root {
+    apply_native_rewrite "NativeRewrite"(%attr : !pdl.attribute)
+  }
+}
+
+// -----
+
 pdl.pattern @attribute_with_dict : benefit(1) {
   %root = operation
   rewrite %root {

--- a/mlir/test/Rewrite/pdl-bytecode.mlir
+++ b/mlir/test/Rewrite/pdl-bytecode.mlir
@@ -72,6 +72,37 @@ module @ir attributes { test.apply_constraint_2 } {
 
 // -----
 
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.op" -> ^bb0, ^end
+
+  ^bb0:
+    %attr = pdl_interp.apply_constraint "check_op_and_get_attr_constr"(%root : !pdl.operation) : !pdl.attribute -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root, %attr : !pdl.operation, !pdl.attribute) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation, %attr : !pdl.attribute) {
+      %op = pdl_interp.create_operation "test.success" {"attr" = %attr}
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.apply_constraint_3
+// CHECK: "test.success"() {attr = "test.success"}
+module @ir attributes { test.apply_constraint_3 } {
+  "test.op"() : () -> ()
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // pdl_interp::ApplyRewriteOp
 //===----------------------------------------------------------------------===//

--- a/mlir/test/lib/Rewrite/TestPDLByteCode.cpp
+++ b/mlir/test/lib/Rewrite/TestPDLByteCode.cpp
@@ -30,6 +30,15 @@ static LogicalResult customMultiEntityVariadicConstraint(
   return success();
 }
 
+// Custom constraint that returns a value
+static LogicalResult customResultConstraint(PatternRewriter &rewriter,
+                                            PDLResultList &results,
+                                            ArrayRef<PDLValue> args) {
+  StringAttr customAttr = rewriter.getStringAttr("test.success");
+  results.push_back(customAttr);
+  return success();
+}
+
 // Custom creator invoked from PDL.
 static Operation *customCreate(PatternRewriter &rewriter, Operation *op) {
   return rewriter.create(OperationState(op->getLoc(), "test.success"));
@@ -102,6 +111,9 @@ struct TestPDLByteCodePass
                                           customMultiEntityConstraint);
     pdlPattern.registerConstraintFunction("multi_entity_var_constraint",
                                           customMultiEntityVariadicConstraint);
+    pdlPattern.registerRewriteFunction("check_op_and_get_attr_constr",
+                                       customResultConstraint);
+
     pdlPattern.registerRewriteFunction("creator", customCreate);
     pdlPattern.registerRewriteFunction("var_creator",
                                        customVariadicResultCreate);

--- a/mlir/test/mlir-pdll/Parser/constraint-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/constraint-failure.pdll
@@ -158,8 +158,3 @@ Pattern {
 
 // CHECK: expected `;` after native declaration
 Constraint Foo() [{}]
-
-// -----
-
-// CHECK: native Constraints currently do not support returning results
-Constraint Foo() -> Op;

--- a/mlir/test/mlir-pdll/Parser/constraint.pdll
+++ b/mlir/test/mlir-pdll/Parser/constraint.pdll
@@ -12,6 +12,14 @@ Constraint Foo() [{ /* Native Code */ }];
 
 // -----
 
+// Test that native constraints support returning results.
+
+// CHECK:  Module
+// CHECK:  `-UserConstraintDecl {{.*}} Name<Foo> ResultType<Attr>
+Constraint Foo() -> Attr;
+
+// -----
+
 // CHECK: Module
 // CHECK: `-UserConstraintDecl {{.*}} Name<Foo> ResultType<Value>
 // CHECK:   `Inputs`


### PR DESCRIPTION
This PR adds support for PDLL native constraints to return results. 
This is useful for situations where a pattern checks for certain constraints of multiple interdependent attributes and computes a new attribute value based on them. Currently we do this check natively in C++ during matching and after a successful match have to escape to native C++ again to do the computation during the rewriting part of the pattern. With this PR we can do the computation in C++ during matching and use the result in the rewriting part of the pattern. Effectively this enables a choice in the trade-off of memory consumption during matching vs recomputation of values.

This is a simplified example of a situation where this is useful: We have two operations with certain attributes that have interdependent constraints. For instance `attr_foo: one_of [0, 2, 4, 8]`, `attr_bar: one_of [0, 2, 4, 8]` and `attr_foo == attr_bar`. The pattern should only match if all conditions are true. The new operation should be created with a new attribute which is computed from the two matched attributes e.g. `attr_baz = attr_foo * attr_bar`. For the check we already escape to native C++ and have all values at hand so it makes sense to directly compute the new attribute value as well: 
```PDLL
Constraint checkAndCompute(attr0: Attr, attr1 : Attr) -> Attr;

Pattern example with benefit(1) { 
    let foo = op<dialect.foo>() {attr = attr_foo : Attr}; 
    let bar = op<dialect.bar>(foo) {attr = attr_bar : Attr}; 
    let attr_baz = checkAndCompute(attr_foo, attr_bar); 
    rewrite bar with { 
        let baz = op<dialect.baz>; 
        setAttribute(baz, attr<"\"attr\"">, attr_baz); 
        replace bar with baz; 
    }; 
} 
```

To achieve this the following changes were necessary:
- Remove simple check in PDLL parser to allow native constraints to return results
- Change PDL definition of `pdl.apply_native_constraint` to allow variadic results
- Change PDL_interp definition of `pdl_interp.apply_constraint` to allow variadic results
- Adjust PDLToPDLInterp Pass:
  The input to the pass is an arbitrary number of PDL patterns. The pass collects all predicates
  that are required to match all of the pdl patterns and tries to establish an ordering that allows
  creation of a single efficient matcher function to match all of them. Hence, the pass does not support 
  the creation of a value on the matching side of a pattern out of the box. Simply referring to
  the `pdl.apply_native_constraint` operation is also not possible because the pdl patterns are deleted
  before the pdl_interp dialect operations are created.
  To solve this we record the type of the results in the predicate for the constraint and 
  create __positions__ (how the pass refers to values that are not materialized yet) for them. 
  When a position is evaluated (i.e. used by an op on the rhs of the pattern) we emit a placeholder value
  to enable the creation of the pdl_interp dialect operation. The placeholder value is replaced later 
  when the actual `pdl_interp.apply_constraint` operation is created.
  This is required in all scenarios where a native constraint returns a result that is used on the rhs 
  because said result has to be an input the the pdl_interp rewriter function that is created for the pattern.
  However, the call to this function is always generated before the `pdl_interp.apply_constraint` operation is created.
- Modify Bytecode generator and interpreter:
  Constraint functions which return results have a different type compared to existing constraint functions. 
  They have the same type as native rewrite functions. For this reason they are for now registered as rewrite functions.
  Other options:
  - change the type for all native constraints to include results
  - Note: 
        Now that constraints may produce results it is hard to say what is the exact difference between native constraints
        and native rewrites. The only difference is that native constraints are evaluated during matching and native rewrites
        are evaluated during rewriting. So it might even make sense to unify the two concepts and have a single type for both
        and only a single function to register them, i.e. `registerNativeFunction` instead of `registerConstraintFunction` and `registerRewriteFunction`.

  ByteCode generation: 
    - constraint lookup in ConstrainFunctions or RewriteFunctions depending on whether the constraint produces results
    - allocate memory for results in byte code
  
  ByteCode execution: 
    - execute constraint as ConstraintFunction or RewriteFunction depending on whether it produces results
    - save results in byte code

For a follow-up PR:
- add support for constraints which create and return new operations
- add support for returning ranges from constraints