### PR TITLE
[FXML-2019] Update existing folds to unspecified int overflow

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/TosaFoldConstantAdd.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaFoldConstantAdd.cpp
@@ -26,14 +26,6 @@ struct TosaFoldConstantAdd : public OpRewritePattern<AddOp> {
 
   using OpRewritePattern::OpRewritePattern;
 
-  static APInt computeIntAdd(const APInt &first, const APInt &second) {
-    return first.sadd_sat(second);
-  }
-
-  static APFloat computeFloatAdd(const APFloat &first, const APFloat &second) {
-    return first + second;
-  }
-
   LogicalResult matchAndRewrite(AddOp addOp,
                                 PatternRewriter &rewriter) const override {
     auto leftOp = addOp.getInput1();
@@ -76,13 +68,27 @@ struct TosaFoldConstantAdd : public OpRewritePattern<AddOp> {
     if (isa<IntegerType>(lhsElemType)) {
       assert(isa<IntegerType>(rhsElemType) &&
              isa<IntegerType>(resultType.getElementType()));
+      bool addOverflowed;
+      auto intAdd = [&addOverflowed](const APInt &first, const APInt &second) {
+        bool didOverflow;
+        auto res = first.sadd_ov(second, didOverflow);
+        addOverflowed |= didOverflow;
+        return res;
+      };
       newTensor = applyElementWise<APInt, APInt>(lhsValues, rhsValues,
-                                                 resultType, &computeIntAdd);
+                                                 resultType, intAdd);
+      if (addOverflowed) {
+        addOp->emitWarning(
+            "Addition did overflow. The results are unspecified.");
+      }
     } else {
       assert(isa<FloatType>(lhsElemType) && isa<FloatType>(rhsElemType) &&
              isa<FloatType>(resultType.getElementType()));
-      newTensor = applyElementWise<APFloat, APFloat>(
-          lhsValues, rhsValues, resultType, &computeFloatAdd);
+      auto floatAdd = [](const APFloat &first, const APFloat &second) {
+        return first + second;
+      };
+      newTensor = applyElementWise<APFloat, APFloat>(lhsValues, rhsValues,
+                                                     resultType, floatAdd);
     }
     rewriter.replaceOpWithNewOp<ConstOp>(addOp, newTensor.getType(), newTensor);
 

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaFoldConstantAdd.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaFoldConstantAdd.cpp
@@ -68,7 +68,7 @@ struct TosaFoldConstantAdd : public OpRewritePattern<AddOp> {
     if (isa<IntegerType>(lhsElemType)) {
       assert(isa<IntegerType>(rhsElemType) &&
              isa<IntegerType>(resultType.getElementType()));
-      bool addOverflowed;
+      bool addOverflowed = false;
       auto intAdd = [&addOverflowed](const APInt &first, const APInt &second) {
         bool didOverflow;
         auto res = first.sadd_ov(second, didOverflow);

--- a/mlir/test/Dialect/Tosa/constant-add-opt.mlir
+++ b/mlir/test/Dialect/Tosa/constant-add-opt.mlir
@@ -75,7 +75,9 @@ func.func @add_fold_int() -> tensor<4xi32> {
 
 // CHECK-LABEL: @add_fold_int_overflow
 func.func @add_fold_int_overflow() -> tensor<4xi32> {
-  // CHECK: [[RES:]] ={{.*}}tosa.const{{.*}}2147483647, 2147483647, -2147483648, -2147483648
+  // Don't expect any specific results for the overflowing addition, just
+  // expect that it is folded.
+  // CHECK: [[RES:]] ={{.*}}tosa.const
   // CHECK-NOT: tosa.add
   // CHECK: return [[RES]]
   %0 = "tosa.const"() {value =
@@ -86,6 +88,7 @@ func.func @add_fold_int_overflow() -> tensor<4xi32> {
                         dense<[1, 10, -1, -30]> :
                         tensor<4xi32>
                       } : () -> tensor<4xi32>
+  // expected-warning@below {{Addition did overflow. The results are unspecified.}}
   %2 = "tosa.add"(%0, %1) : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
   return %2 : tensor<4xi32>
 }


### PR DESCRIPTION
* Adapt `add`
* `pow`/`sqrt`/`reciprocal`operate only on floats
* `cast` has its own definition for these cases
* `clamp` is not affected
