### PR TITLE
FXML.2007: PDLL support for creating new ops with empty regions

### DIFF
--- a/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
@@ -346,7 +346,8 @@ def PDL_OperationOp : PDL_Op<"operation", [AttrSizedOperandSegments]> {
                        Variadic<PDL_InstOrRangeOf<PDL_Value>>:$operandValues,
                        Variadic<PDL_Attribute>:$attributeValues,
                        StrArrayAttr:$attributeValueNames,
-                       Variadic<PDL_InstOrRangeOf<PDL_Type>>:$typeValues);
+                       Variadic<PDL_InstOrRangeOf<PDL_Type>>:$typeValues,
+                       OptionalAttr<UI32Attr>:$numRegions);
   let results = (outs PDL_Operation:$op);
   let assemblyFormat = [{
     ($opName^)? (`(` $operandValues^ `:` type($operandValues) `)`)?
@@ -363,7 +364,7 @@ def PDL_OperationOp : PDL_Op<"operation", [AttrSizedOperandSegments]> {
       auto nameAttr = name ? $_builder.getStringAttr(*name) : StringAttr();
       build($_builder, $_state, $_builder.getType<OperationType>(), nameAttr,
             operandValues, attrValues, $_builder.getStrArrayAttr(attrNames),
-            resultTypes);
+            resultTypes, nullptr);
     }]>,
   ];
   let extraClassDeclaration = [{

--- a/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
@@ -362,9 +362,10 @@ def PDL_OperationOp : PDL_Op<"operation", [AttrSizedOperandSegments]> {
       CArg<"ValueRange", "llvm::None">:$attrValues,
       CArg<"ValueRange", "llvm::None">:$resultTypes), [{
       auto nameAttr = name ? $_builder.getStringAttr(*name) : StringAttr();
+      IntegerAttr numRegionsAttr;
       build($_builder, $_state, $_builder.getType<OperationType>(), nameAttr,
             operandValues, attrValues, $_builder.getStrArrayAttr(attrNames),
-            resultTypes, nullptr);
+            resultTypes, numRegionsAttr);
     }]>,
   ];
   let extraClassDeclaration = [{

--- a/mlir/include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td
+++ b/mlir/include/mlir/Dialect/PDLInterp/IR/PDLInterpOps.td
@@ -430,15 +430,24 @@ def PDLInterp_CreateOperationOp
                        Variadic<PDL_Attribute>:$inputAttributes,
                        StrArrayAttr:$inputAttributeNames,
                        Variadic<PDL_InstOrRangeOf<PDL_Type>>:$inputResultTypes,
-                       UnitAttr:$inferredResultTypes);
+                       UnitAttr:$inferredResultTypes,
+                       OptionalAttr<UI32Attr>:$numRegions);
   let results = (outs PDL_Operation:$resultOp);
 
   let builders = [
     OpBuilder<(ins "StringRef":$name, "ValueRange":$types,
       "bool":$inferredResultTypes, "ValueRange":$operands,
       "ValueRange":$attributes, "ArrayAttr":$attributeNames), [{
+      IntegerAttr numRegionsAttr;
       build($_builder, $_state, $_builder.getType<pdl::OperationType>(), name,
-            operands, attributes, attributeNames, types, inferredResultTypes);
+            operands, attributes, attributeNames, types, inferredResultTypes, numRegionsAttr);
+    }]>,
+    OpBuilder<(ins "StringRef":$name, "ValueRange":$types,
+      "bool":$inferredResultTypes, "ValueRange":$operands,
+      "ValueRange":$attributes, "ArrayAttr":$attributeNames, "uint32_t":$numRegions), [{
+      auto numRegionsAttr = $_builder.getUI32IntegerAttr(numRegions);
+      build($_builder, $_state, $_builder.getType<pdl::OperationType>(), name,
+            operands, attributes, attributeNames, types, inferredResultTypes, numRegionsAttr);
     }]>
   ];
   let assemblyFormat = [{

--- a/mlir/include/mlir/Tools/PDLL/AST/Nodes.h
+++ b/mlir/include/mlir/Tools/PDLL/AST/Nodes.h
@@ -501,12 +501,11 @@ class OperationExpr final
       private llvm::TrailingObjects<OperationExpr, Expr *,
                                     NamedAttributeDecl *> {
 public:
-  static OperationExpr *create(Context &ctx, SMRange loc,
-                               const ods::Operation *odsOp,
-                               const OpNameDecl *nameDecl,
-                               ArrayRef<Expr *> operands,
-                               ArrayRef<Expr *> resultTypes,
-                               ArrayRef<NamedAttributeDecl *> attributes);
+  static OperationExpr *
+  create(Context &ctx, SMRange loc, const ods::Operation *odsOp,
+         const OpNameDecl *nameDecl, ArrayRef<Expr *> operands,
+         ArrayRef<Expr *> resultTypes,
+         ArrayRef<NamedAttributeDecl *> attributes, unsigned numRegions);
 
   /// Return the name of the operation, or None if there isn't one.
   Optional<StringRef> getName() const;
@@ -542,19 +541,22 @@ public:
     return const_cast<OperationExpr *>(this)->getAttributes();
   }
 
+  unsigned getNumRegions() const { return numRegions; }
+
 private:
   OperationExpr(SMRange loc, Type type, const OpNameDecl *nameDecl,
                 unsigned numOperands, unsigned numResultTypes,
-                unsigned numAttributes, SMRange nameLoc)
+                unsigned numAttributes, unsigned numRegions, SMRange nameLoc)
       : Base(loc, type), nameDecl(nameDecl), numOperands(numOperands),
         numResultTypes(numResultTypes), numAttributes(numAttributes),
-        nameLoc(nameLoc) {}
+        numRegions(numRegions), nameLoc(nameLoc) {}
 
   /// The name decl of this expression.
   const OpNameDecl *nameDecl;
 
-  /// The number of operands, result types, and attributes of the operation.
-  unsigned numOperands, numResultTypes, numAttributes;
+  /// The number of operands, result types, attributes and regions of the
+  /// operation.
+  unsigned numOperands, numResultTypes, numAttributes, numRegions;
 
   /// The location of the operation name in the expression if it has a name.
   SMRange nameLoc;

--- a/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
@@ -765,10 +765,9 @@ void PatternLowering::generateRewriter(
   generateOperationResultTypeRewriter(operationOp, mapRewriteValue, types,
                                       rewriteValues, hasInferredResultTypes);
 
-  auto numRegions = operationOp.getNumRegions().value_or(0);
-
   // Create the new operation.
   Location loc = operationOp.getLoc();
+  auto numRegions = operationOp.getNumRegions().value_or(0);
   Value createdOp = builder.create<pdl_interp::CreateOperationOp>(
       loc, *operationOp.getOpName(), types, hasInferredResultTypes, operands,
       attributes, operationOp.getAttributeValueNames(), numRegions);

--- a/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
@@ -765,11 +765,13 @@ void PatternLowering::generateRewriter(
   generateOperationResultTypeRewriter(operationOp, mapRewriteValue, types,
                                       rewriteValues, hasInferredResultTypes);
 
+  auto numRegions = operationOp.getNumRegions().value_or(0);
+
   // Create the new operation.
   Location loc = operationOp.getLoc();
   Value createdOp = builder.create<pdl_interp::CreateOperationOp>(
       loc, *operationOp.getOpName(), types, hasInferredResultTypes, operands,
-      attributes, operationOp.getAttributeValueNames());
+      attributes, operationOp.getAttributeValueNames(), numRegions);
   rewriteValues[operationOp.getOp()] = createdOp;
 
   // Generate accesses for any results that have their types constrained.

--- a/mlir/lib/Dialect/PDL/IR/PDL.cpp
+++ b/mlir/lib/Dialect/PDL/IR/PDL.cpp
@@ -141,6 +141,8 @@ LogicalResult OperandsOp::verify() { return verifyHasBindingUse(*this); }
 // pdl::OperationOp
 //===----------------------------------------------------------------------===//
 
+/// Handles parsing of OperationOpAttributes, e.g. {"attr" = %attribute}.
+/// Also allows empty `{}`
 static ParseResult parseOperationOpAttributes(
     OpAsmParser &p,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &attrOperands,
@@ -167,6 +169,9 @@ static ParseResult parseOperationOpAttributes(
   return success();
 }
 
+/// Handles printing of OperationOpAttributes, e.g. {"attr" = %attribute}.
+/// Prints empty `{}` when it would not be possible to discern the attr-dict
+/// otherwise.
 static void printOperationOpAttributes(OpAsmPrinter &p, OperationOp op,
                                        OperandRange attrArgs,
                                        ArrayAttr attrNames) {

--- a/mlir/lib/Dialect/PDL/IR/PDL.cpp
+++ b/mlir/lib/Dialect/PDL/IR/PDL.cpp
@@ -148,18 +148,20 @@ static ParseResult parseOperationOpAttributes(
   Builder &builder = p.getBuilder();
   SmallVector<Attribute, 4> attrNames;
   if (succeeded(p.parseOptionalLBrace())) {
-    auto parseOperands = [&]() {
-      StringAttr nameAttr;
-      OpAsmParser::UnresolvedOperand operand;
-      if (p.parseAttribute(nameAttr) || p.parseEqual() ||
-          p.parseOperand(operand))
+    if (failed(p.parseOptionalRBrace())) {
+      auto parseOperands = [&]() {
+        StringAttr nameAttr;
+        OpAsmParser::UnresolvedOperand operand;
+        if (p.parseAttribute(nameAttr) || p.parseEqual() ||
+            p.parseOperand(operand))
+          return failure();
+        attrNames.push_back(nameAttr);
+        attrOperands.push_back(operand);
+        return success();
+      };
+      if (p.parseCommaSeparatedList(parseOperands) || p.parseRBrace())
         return failure();
-      attrNames.push_back(nameAttr);
-      attrOperands.push_back(operand);
-      return success();
-    };
-    if (p.parseCommaSeparatedList(parseOperands) || p.parseRBrace())
-      return failure();
+    }
   }
   attrNamesAttr = builder.getArrayAttr(attrNames);
   return success();

--- a/mlir/lib/Dialect/PDLInterp/IR/PDLInterp.cpp
+++ b/mlir/lib/Dialect/PDLInterp/IR/PDLInterp.cpp
@@ -64,6 +64,8 @@ LogicalResult CreateOperationOp::verify() {
   return success();
 }
 
+/// Handles parsing of OperationOpAttributes, e.g. {"attr" = %attribute}.
+/// Also allows empty `{}`
 static ParseResult parseCreateOperationOpAttributes(
     OpAsmParser &p,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &attrOperands,
@@ -90,6 +92,9 @@ static ParseResult parseCreateOperationOpAttributes(
   return success();
 }
 
+/// Handles printing of OperationOpAttributes, e.g. {"attr" = %attribute}.
+/// Prints empty `{}` when it would not be possible to discern the attr-dict
+/// otherwise.
 static void printCreateOperationOpAttributes(OpAsmPrinter &p,
                                              CreateOperationOp op,
                                              OperandRange attrArgs,

--- a/mlir/lib/Rewrite/ByteCode.cpp
+++ b/mlir/lib/Rewrite/ByteCode.cpp
@@ -22,7 +22,6 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/FormatVariadic.h"
-#include <iostream>
 #include <numeric>
 
 #define DEBUG_TYPE "pdl-bytecode"
@@ -888,7 +887,7 @@ void Generator::generate(pdl_interp::CreateOperationOp op,
     writer.appendPDLValueList(op.getInputResultTypes());
 
   // Add number of regions
-  if (IntegerAttr attr = op->getAttrOfType<IntegerAttr>("numRegions")) {
+  if (IntegerAttr attr = op.getNumRegionsAttr()) {
     writer.append(ByteCodeField(attr.getUInt()));
   } else {
     unsigned numRegions = 0;

--- a/mlir/lib/Tools/PDLL/AST/NodePrinter.cpp
+++ b/mlir/lib/Tools/PDLL/AST/NodePrinter.cpp
@@ -247,7 +247,7 @@ void NodePrinter::printImpl(const MemberAccessExpr *expr) {
 void NodePrinter::printImpl(const OperationExpr *expr) {
   os << "OperationExpr " << expr << " Type<";
   print(expr->getType());
-  os << ">\n";
+  os << "> numRegions:" << expr->getNumRegions() << "\n";
 
   printChildren(expr->getNameDecl());
   printChildren("Operands", expr->getOperands());

--- a/mlir/lib/Tools/PDLL/AST/Nodes.cpp
+++ b/mlir/lib/Tools/PDLL/AST/Nodes.cpp
@@ -301,11 +301,13 @@ MemberAccessExpr *MemberAccessExpr::create(Context &ctx, SMRange loc,
 // OperationExpr
 //===----------------------------------------------------------------------===//
 
-OperationExpr *
-OperationExpr::create(Context &ctx, SMRange loc, const ods::Operation *odsOp,
-                      const OpNameDecl *name, ArrayRef<Expr *> operands,
-                      ArrayRef<Expr *> resultTypes,
-                      ArrayRef<NamedAttributeDecl *> attributes) {
+OperationExpr *OperationExpr::create(Context &ctx, SMRange loc,
+                                     const ods::Operation *odsOp,
+                                     const OpNameDecl *name,
+                                     ArrayRef<Expr *> operands,
+                                     ArrayRef<Expr *> resultTypes,
+                                     ArrayRef<NamedAttributeDecl *> attributes,
+                                     unsigned numRegions) {
   unsigned allocSize =
       OperationExpr::totalSizeToAlloc<Expr *, NamedAttributeDecl *>(
           operands.size() + resultTypes.size(), attributes.size());
@@ -315,7 +317,7 @@ OperationExpr::create(Context &ctx, SMRange loc, const ods::Operation *odsOp,
   Type resultType = OperationType::get(ctx, name->getName(), odsOp);
   OperationExpr *opExpr = new (rawData)
       OperationExpr(loc, resultType, name, operands.size(), resultTypes.size(),
-                    attributes.size(), name->getLoc());
+                    attributes.size(), numRegions, name->getLoc());
   std::uninitialized_copy(operands.begin(), operands.end(),
                           opExpr->getOperands().begin());
   std::uninitialized_copy(resultTypes.begin(), resultTypes.end(),

--- a/mlir/lib/Tools/PDLL/CodeGen/MLIRGen.cpp
+++ b/mlir/lib/Tools/PDLL/CodeGen/MLIRGen.cpp
@@ -515,8 +515,14 @@ Value CodeGen::genExprImpl(const ast::OperationExpr *expr) {
   for (const ast::Expr *result : expr->getResultTypes())
     results.push_back(genSingleExpr(result));
 
-  return builder.create<pdl::OperationOp>(loc, opName, operands, attrNames,
-                                          attrValues, results);
+  auto operationOp = builder.create<pdl::OperationOp>(
+      loc, opName, operands, attrNames, attrValues, results);
+
+  // numRegions
+  if (expr->getNumRegions() > 0) {
+    operationOp.setNumRegions(expr->getNumRegions());
+  }
+  return operationOp;
 }
 
 Value CodeGen::genExprImpl(const ast::RangeExpr *expr) {

--- a/mlir/lib/Tools/PDLL/CodeGen/MLIRGen.cpp
+++ b/mlir/lib/Tools/PDLL/CodeGen/MLIRGen.cpp
@@ -519,9 +519,9 @@ Value CodeGen::genExprImpl(const ast::OperationExpr *expr) {
       loc, opName, operands, attrNames, attrValues, results);
 
   // numRegions
-  if (expr->getNumRegions() > 0) {
+  if (expr->getNumRegions() > 0)
     operationOp.setNumRegions(expr->getNumRegions());
-  }
+
   return operationOp;
 }
 

--- a/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-rewriter.mlir
+++ b/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-rewriter.mlir
@@ -267,12 +267,12 @@ module @range_op {
 module @create_empty_region {
   // CHECK: module @rewriters
   // CHECK:   func @pdl_generated_rewriter()
-  // CHECK:     %[[UNUSED:.*]] = pdl_interp.create_operation "bar.op" {numRegions = 1 : ui32}
+  // CHECK:     %[[UNUSED:.*]] = pdl_interp.create_operation "bar.op" {} {numRegions = 1 : ui32}
   // CHECK:     pdl_interp.finalize
   pdl.pattern : benefit(1) {
     %root = operation "foo.op"
     rewrite %root {
-      %unused = operation "bar.op"{} {"numRegions" = 1 : ui32}
+      %unused = operation "bar.op" {} {"numRegions" = 1 : ui32}
     }
   }
 }

--- a/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-rewriter.mlir
+++ b/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-rewriter.mlir
@@ -260,3 +260,19 @@ module @range_op {
     }
   }
 }
+
+// -----
+
+// CHECK-LABEL: module @create_empty_region
+module @create_empty_region {
+  // CHECK: module @rewriters
+  // CHECK:   func @pdl_generated_rewriter()
+  // CHECK:     %[[UNUSED:.*]] = pdl_interp.create_operation "bar.op" {numRegions = 1 : ui32}
+  // CHECK:     pdl_interp.finalize
+  pdl.pattern : benefit(1) {
+    %root = operation "foo.op"
+    rewrite %root {
+      %unused = operation "bar.op"{} {"numRegions" = 1 : ui32}
+    }
+  }
+}

--- a/mlir/test/Dialect/PDL/ops.mlir
+++ b/mlir/test/Dialect/PDL/ops.mlir
@@ -173,3 +173,39 @@ pdl.pattern @attribute_with_loc : benefit(1) {
   %root = operation {"attribute" = %attr}
   rewrite %root with "rewriter"
 }
+
+// -----
+
+// Check that we can attach a numRegions attribute to pdl.operation
+
+pdl.pattern @num_regions : benefit(1) {
+  // CHECK-GENERIC: "pdl.attribute"
+  // CHECK-GENERIC-NOT: value = loc
+  %root = operation {} {numRegions = 1 : ui32}
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+pdl.pattern @num_regions_with_attr_vals : benefit(1) {
+  %attr = attribute
+  %root = operation {"attribute" = %attr} {numRegions = 1 : ui32}
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+pdl.pattern @num_regions_with_operands : benefit(1) {
+  %types = types
+  %operands = operands : %types
+  %root = operation (%operands : !pdl.range<value>) {} {numRegions = 1 : ui32}
+  rewrite %root with "rewriter"
+}
+
+// -----
+
+pdl.pattern @num_regions_with_results : benefit(1) {
+  %types = types
+  %root = operation -> (%types : !pdl.range<type>) {numRegions = 1 : ui32}
+  rewrite %root with "rewriter"
+}

--- a/mlir/test/Dialect/PDLInterp/ops.mlir
+++ b/mlir/test/Dialect/PDLInterp/ops.mlir
@@ -28,6 +28,9 @@ func.func @operations(%attribute: !pdl.attribute,
   // inferred results
   %op4 = pdl_interp.create_operation "arith.constant" -> <inferred>
 
+  // region
+  %op5 = pdl_interp.create_operation "foo.op" {} {"numRegions" = 1 : ui32}
+
   pdl_interp.finalize
 }
 

--- a/mlir/test/Rewrite/pdl-bytecode.mlir
+++ b/mlir/test/Rewrite/pdl-bytecode.mlir
@@ -599,6 +599,37 @@ module @ir attributes { test.create_op_infer_results } {
 
 // -----
 
+// Test support for creating an operation with an empty region.
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.op" -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@success(%root : !pdl.operation) : benefit(1), loc([%root]) -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @success(%root : !pdl.operation) {
+      %op = pdl_interp.create_operation "test.success" {} {"numRegions" = 1 : ui32}
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK-LABEL: test.create_op_with_empty_region
+// CHECK: "test.success"() ({
+// CHECK-NEXT: }) : () -> ()
+module @ir attributes { test.create_op_with_empty_region } {
+  "test.op"() : () -> ()
+}
+
+// -----
+
+
 //===----------------------------------------------------------------------===//
 // pdl_interp::CreateRangeOp
 //===----------------------------------------------------------------------===//

--- a/mlir/test/mlir-pdll/Parser/expr.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr.pdll
@@ -241,6 +241,29 @@ Pattern {
 
 // -----
 
+// Test parsing of an op with an empty region
+
+// CHECK: Module
+// CHECK:  -PatternDecl {{.*}}
+// CHECK:  -RewriteStmt {{.*}}
+// CHECK:  -OperationExpr {{.*}} Type<Op<test.foo>>
+// CHECK-SAME: numRegions:0
+// CHECK:    `Operands`
+// CHECK:    `Result Types`
+// CHECK:    `Attributes`
+// CHECK:  -OperationExpr {{.*}} Type<Op<test.foo_with_region>>
+// CHECK-SAME: numRegions:1
+// CHECK:    `Operands`
+// CHECK:    `Result Types`
+// CHECK:    `Attributes`
+Pattern {
+  rewrite op<test.foo>(operand: Value) {attr=attr: Attr} -> (type : Type) with {
+    op<test.foo_with_region>(operand) {attr=attr} -> (type) ({});
+  };
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // TupleExpr
 //===----------------------------------------------------------------------===//

--- a/mlir/test/mlir-pdll/Parser/stmt-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/stmt-failure.pdll
@@ -98,6 +98,27 @@ Pattern {
 // -----
 
 Pattern {
+  // CHECK: expected `)` to close region list
+  let foo = op<>() ({};
+}
+
+// -----
+
+Pattern {
+  // CHECK: expected `}` to close region
+  let foo = op<>() ({;
+}
+
+// -----
+
+Pattern {
+  // CHECK: expected `{` to open region
+  let foo = op<>() ();
+}
+
+// -----
+
+Pattern {
   // CHECK: expected expression
   let foo: Value<>;
 }


### PR DESCRIPTION
This PR extends PDLL and the underlying PDL, PDL_Interp and byte code interpreter components with support for creating new operations with empty regions.
This is an initial step towards adding full support for operations with regions, i.e. generating an operation with a region and new nested ops within that region.

However, this PR already enables expressing some patterns with less (or at least more generic) native calls. 
Here is an example of creating a new operation with a region and nesting other operations into it:

Without this PR this Pattern looks like:
```
Rewrite createOpWithRegion() -> Op;
Rewrite addAttributeToOp(op: Op, attr: Attr) -> Op;
Rewrite moveOpsIntoRegion(op: Op, results: ValueRange);


Pattern op_with_region_old with benefit(3) {
    let root = op<test.op>() {"attr" = someAttr : Attr} -> (type: Type);

    rewrite root with {
        let nestedOp = op<test.nested_op>();
        let op_with_region = createOpWithRegion();
        addAttributeToOp(op_with_region, someAttr);
        moveOpsIntoRegion(op_with_region, (nestedOp.0));

        replace root with op_with_region;
    };
}
```
With this PR it is more obvious what this pattern does as we use more builtin PDLL constructs for creating the operation and attaching the attribute. The moving of operations into the region can still only be accomplished with a native call.
```
Rewrite moveOpsIntoRegion(op: Op, results: ValueRange);

Pattern op_with_region with benefit(1) {
    let root = op<test.op>() {"attr" = someAttr : Attr} -> (type: Type);

    rewrite root with {
        let nestedOp = op<test.nested_op>();
        let op_with_region = op<test.op_with_region>() {attr=someAttr} -> (type) ({});
        moveOpsIntoRegion(op_with_region, (nestedOp.0));

        replace root with op_with_region;
    };
}
```

To achieve this the following changes were necessary:

- Extend PDLL parser to parse a trailing `({}, ... , {})` into the number of regions
- Extend `pdl.operation` and `pdl_interp.create_operation` with an optional `numRegions` attribute
- Fix parsing and printing of both ops as it clashes with the trailing attr-dict in some cases
    - We print empty braces `{}` when attribute SSA values are missing in some cases to discern them from the trailing attribute 
- Add support for attaching empty regions to an operation in the byte code interpreter 

Eventually, this initial design should be expanded with proper support for creating nested operations.