### PR TITLE
[FXML-1991] Reciprocal Constant Folding For a Splat Tensor

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -1057,6 +1057,8 @@ def Tosa_ReciprocalOp : Tosa_Op<"reciprocal", [
   let results = (outs
     Tosa_Tensor:$output
   );
+
+  let hasFolder = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -679,9 +679,6 @@ OpFoldResult SubOp::fold(ArrayRef<Attribute> operands) {
   if (!lhsAttr || !rhsAttr)
     return {};
 
-  if (lhsTy != rhsTy)
-    return {};
-
   return binaryFolder<std::minus<APInt>, std::minus<APFloat>>(lhsAttr, rhsAttr,
                                                               lhsTy);
 }

--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -643,10 +643,6 @@ OpFoldResult ReciprocalOp::fold(ArrayRef<Attribute> operands) {
 
   auto floatVal = constantAttr.getSplatValue<llvm::APFloat>();
 
-  if (!floatVal.isFiniteNonZero()) {
-    return {};
-  }
-
   auto recipAttr = FloatAttr::get(lhsTy.getElementType(), 1.0);
   APFloat recip = recipAttr.getValue();
   recip.divide(floatVal, APFloat::rmNearestTiesToEven);

--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -630,8 +630,8 @@ OpFoldResult MulOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult ReciprocalOp::fold(ArrayRef<Attribute> operands) {
-  auto constantAttr = operands[0].dyn_cast_or_null<DenseElementsAttr>();
-  auto lhsTy = getInput1().getType().dyn_cast<RankedTensorType>();
+  auto constantAttr = dyn_cast_or_null<DenseElementsAttr>(operands[0]);
+  auto lhsTy = dyn_cast<RankedTensorType>(getInput1().getType());
 
   if (!lhsTy || !constantAttr) {
     return {};

--- a/mlir/test/Dialect/Tosa/constant-op-fold.mlir
+++ b/mlir/test/Dialect/Tosa/constant-op-fold.mlir
@@ -317,6 +317,18 @@ func.func @fold_reciprocal_splat_f32() -> tensor<f32> {
 
 // -----
 
+// CHECK-LABEL: @fold_reciprocal_splat_zero_f32
+func.func @fold_reciprocal_splat_zero_f32() -> tensor<f32> {
+  %zero = "tosa.const"() {value = dense<0.0> : tensor<f32>} : () -> tensor<f32>
+  %recp = "tosa.reciprocal"(%zero) : (tensor<f32>) -> tensor<f32>
+  // 0x7F800000 represents +inf as we have computed 1/0
+  // CHECK: %[[CST:.*]] = "tosa.const"() {value = dense<0x7F800000> : tensor<f32>}
+  // CHECK: return %[[CST]]
+  return %recp : tensor<f32>
+}
+
+// -----
+
 // CHECK-LABEL: @fold_sub_zero_rhs_f32
 func.func @fold_sub_zero_rhs_f32(%arg0: tensor<f32>) -> tensor<f32> {
   %zero = "tosa.const"() {value = dense<0.0> : tensor<f32>} : () -> tensor<f32>

--- a/mlir/test/Dialect/Tosa/constant-op-fold.mlir
+++ b/mlir/test/Dialect/Tosa/constant-op-fold.mlir
@@ -306,6 +306,17 @@ func.func @fold_mul_splat_f32() -> tensor<10xf32> {
 
 // -----
 
+// CHECK-LABEL: @fold_reciprocal_splat_f32
+func.func @fold_reciprocal_splat_f32() -> tensor<f32> {
+  %half = "tosa.const"() {value = dense<0.5> : tensor<f32>} : () -> tensor<f32>
+  %recp = "tosa.reciprocal"(%half) : (tensor<f32>) -> tensor<f32>
+  // CHECK: %[[CST:.*]] = "tosa.const"() {value = dense<2.000000e+00> : tensor<f32>}
+  // CHECK: return %[[CST]]
+  return %recp : tensor<f32>
+}
+
+// -----
+
 // CHECK-LABEL: @fold_sub_zero_rhs_f32
 func.func @fold_sub_zero_rhs_f32(%arg0: tensor<f32>) -> tensor<f32> {
   %zero = "tosa.const"() {value = dense<0.0> : tensor<f32>} : () -> tensor<f32>


### PR DESCRIPTION
Quantization Operations in TOSA are represnted using the following operators:
```
    %0 = "tosa.const"() {value = dense<3.125000e-02> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
    %1 = "tosa.reciprocal"(%0) : (tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
    %2 = "tosa.mul"(%arg0, %1) {LayerName = "QuantizeLinear_2", shift = 0 : i32} : (tensor<32x3x224x224xf32>, tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xf32>
    %3 = "tosa.cast"(%2) : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8>
```
Here we apply the reciprocal of a constant scale factor which can be easily folded into the constant.

These changes introduce that folding to help simplify possible pattern matching later on. 