### PR TITLE
[FXML-1991] Update Add and Sub Constant Folding

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -474,8 +474,6 @@ OpFoldResult AddOp::fold(ArrayRef<Attribute> operands) {
   auto resultTy = getType().dyn_cast<RankedTensorType>();
   if (!lhsTy || !rhsTy || !resultTy)
     return {};
-  if (lhsTy.getRank() != rhsTy.getRank())
-    return {};
 
   auto resultETy = resultTy.getElementType();
   auto lhsAttr = operands[0].dyn_cast_or_null<DenseElementsAttr>();
@@ -637,8 +635,6 @@ OpFoldResult SubOp::fold(ArrayRef<Attribute> operands) {
   auto rhsTy = getInput2().getType().dyn_cast<RankedTensorType>();
   auto resultTy = getType().dyn_cast<RankedTensorType>();
   if (!lhsTy || !rhsTy || !resultTy)
-    return {};
-  if (lhsTy.getRank() != rhsTy.getRank())
     return {};
 
   auto resultETy = resultTy.getElementType();

--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -474,7 +474,7 @@ OpFoldResult AddOp::fold(ArrayRef<Attribute> operands) {
   auto resultTy = getType().dyn_cast<RankedTensorType>();
   if (!lhsTy || !rhsTy || !resultTy)
     return {};
-  if (lhsTy != rhsTy)
+  if (lhsTy.getRank() != rhsTy.getRank())
     return {};
 
   auto resultETy = resultTy.getElementType();
@@ -502,6 +502,9 @@ OpFoldResult AddOp::fold(ArrayRef<Attribute> operands) {
   }
 
   if (!lhsAttr || !rhsAttr)
+    return {};
+
+  if (lhsTy != rhsTy)
     return {};
 
   return binaryFolder<std::plus<APInt>, std::plus<APFloat>>(lhsAttr, rhsAttr,
@@ -635,7 +638,7 @@ OpFoldResult SubOp::fold(ArrayRef<Attribute> operands) {
   auto resultTy = getType().dyn_cast<RankedTensorType>();
   if (!lhsTy || !rhsTy || !resultTy)
     return {};
-  if (lhsTy != rhsTy)
+  if (lhsTy.getRank() != rhsTy.getRank())
     return {};
 
   auto resultETy = resultTy.getElementType();
@@ -653,6 +656,9 @@ OpFoldResult SubOp::fold(ArrayRef<Attribute> operands) {
   }
 
   if (!lhsAttr || !rhsAttr)
+    return {};
+
+  if (lhsTy != rhsTy)
     return {};
 
   return binaryFolder<std::minus<APInt>, std::minus<APFloat>>(lhsAttr, rhsAttr,

--- a/mlir/test/Dialect/Tosa/constant-op-fold.mlir
+++ b/mlir/test/Dialect/Tosa/constant-op-fold.mlir
@@ -167,9 +167,21 @@ func.func @fold_add_splat_f32() -> tensor<10xf32> {
 // CHECK-LABEL: @fold_add_zero_splat_different_shape_f32
 func.func @fold_add_zero_splat_different_shape_f32(%arg0: tensor<1x10xf32>) -> tensor<1x10xf32> {
   %zero = "tosa.const"() {value = dense<0.0> : tensor<1x1xf32>} : () -> tensor<1x1xf32>
-  %sub = "tosa.add"(%arg0, %zero) : (tensor<1x10xf32>, tensor<1x1xf32>) -> tensor<1x10xf32>
+  %add = "tosa.add"(%arg0, %zero) : (tensor<1x10xf32>, tensor<1x1xf32>) -> tensor<1x10xf32>
   // CHECK: return %arg0
-  return %sub : tensor<1x10xf32>
+  return %add : tensor<1x10xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @fold_add_zero_broadcast_arg_f32
+func.func @fold_add_zero_broadcast_arg_f32(%arg0: tensor<1x10xf32>) -> tensor<4x10xf32> {
+  %zero = "tosa.const"() {value = dense<0.0> : tensor<1x1xf32>} : () -> tensor<4x10xf32>
+  %add = "tosa.add"(%arg0, %zero) : (tensor<1x10xf32>, tensor<4x10xf32>) -> tensor<4x10xf32>
+  // CHECK: %[[ZERO:.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<1x1xf32>} : () -> tensor<4x10xf32>
+  // CHECK: %[[ADD:.+]] = "tosa.add"(%arg0, %[[ZERO]]) : (tensor<1x10xf32>, tensor<4x10xf32>) -> tensor<4x10xf32>
+  // CHECK: return %[[ADD]] : tensor<4x10xf32>
+  return %add : tensor<4x10xf32>
 }
 
 // -----

--- a/mlir/test/Dialect/Tosa/constant-op-fold.mlir
+++ b/mlir/test/Dialect/Tosa/constant-op-fold.mlir
@@ -164,6 +164,16 @@ func.func @fold_add_splat_f32() -> tensor<10xf32> {
 
 // -----
 
+// CHECK-LABEL: @fold_add_zero_splat_different_shape_f32
+func.func @fold_add_zero_splat_different_shape_f32(%arg0: tensor<1x10xf32>) -> tensor<1x10xf32> {
+  %zero = "tosa.const"() {value = dense<0.0> : tensor<1x1xf32>} : () -> tensor<1x1xf32>
+  %sub = "tosa.add"(%arg0, %zero) : (tensor<1x10xf32>, tensor<1x1xf32>) -> tensor<1x10xf32>
+  // CHECK: return %arg0
+  return %sub : tensor<1x10xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @fold_div_zero_lhs_i32
 func.func @fold_div_zero_lhs_i32(%arg0: tensor<i32>) -> tensor<i32> {
   %zero = "tosa.const"() {value = dense<0> : tensor<i32>} : () -> tensor<i32>
@@ -346,6 +356,16 @@ func.func @fold_sub_splat_f32() -> tensor<10xf32> {
   // CHECK: %[[THREE:.+]] = "tosa.const"() {value = dense<-1.000000e+00> : tensor<10xf32>}
   // CHECK: return %[[THREE]]
   return %sub : tensor<10xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @fold_sub_zero_splat_different_shape_f32
+func.func @fold_sub_zero_splat_different_shape_f32(%arg0: tensor<1x10xf32>) -> tensor<1x10xf32> {
+  %zero = "tosa.const"() {value = dense<0.0> : tensor<1x1xf32>} : () -> tensor<1x1xf32>
+  %sub = "tosa.sub"(%arg0, %zero) : (tensor<1x10xf32>, tensor<1x1xf32>) -> tensor<1x10xf32>
+  // CHECK: return %arg0
+  return %sub : tensor<1x10xf32>
 }
 
 // -----


### PR DESCRIPTION
Often times the statements between two casts which represent simple Quantize and Dequantize operations can be simplified as their zero points are zero.
```
    %0 = "tosa.const"() {value = dense<0> : tensor<1x1x1x1xi8>} : () -> tensor<1x1x1x1xi8>
    %1 = "tosa.cast"(%arg0) : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8>
    %2 = "tosa.add"(%1, %0) {OutputName = "QuantizeLinear_2"} : (tensor<32x3x224x224xi8>, tensor<1x1x1x1xi8>) -> tensor<32x3x224x224xi8>
    %3 = "tosa.sub"(%2, %0) {LayerName = "DequantizeLinear_5"} : (tensor<32x3x224x224xi8>, tensor<1x1x1x1xi8>) -> tensor<32x3x224x224xi8>
    %4 = "tosa.cast"(%3) : (tensor<32x3x224x224xi8>) -> tensor<32x3x224x224xf32>
```
The add and sub statements are then redundant and do no work as the constants to these operations are zero. The add and sub operations can then be removed to simplify the IR for pattern matching. 
