### PR TITLE
fix fused native constraints with results

### DIFF
--- a/mlir/lib/Rewrite/ByteCode.cpp
+++ b/mlir/lib/Rewrite/ByteCode.cpp
@@ -1438,6 +1438,7 @@ void ByteCodeExecutor::executeApplyConstraint(PatternRewriter &rewriter) {
   LLVM_DEBUG({
     llvm::dbgs() << "  * Arguments: ";
     llvm::interleaveComma(args, llvm::dbgs());
+    llvm::dbgs() << "\n";
   });
 
   ByteCodeField numResults = read();
@@ -1450,12 +1451,26 @@ void ByteCodeExecutor::executeApplyConstraint(PatternRewriter &rewriter) {
     const PDLRewriteFunction &constraintFn = rewriteFunctions[fun_idx];
     ByteCodeRewriteResultList results(numResults);
     LogicalResult rewriteResult = constraintFn(rewriter, results, args);
-    assert(results.getResults().size() == numResults &&
-           "native PDL rewrite function returned unexpected number of results");
-
-    for (PDLValue &result : results.getResults()) {
-      LLVM_DEBUG(llvm::dbgs() << "  * Result: " << result << "\n");
-      memory[read()] = result.getAsOpaquePointer();
+    ArrayRef<PDLValue> constraintResults = results.getResults();
+    LLVM_DEBUG({
+      if (succeeded(rewriteResult)) {
+        llvm::dbgs() << "  * Constraint succeeded\n";
+        llvm::dbgs() << "  * Results: ";
+        llvm::interleaveComma(constraintResults, llvm::dbgs());
+        llvm::dbgs() << "\n";
+      } else {
+        llvm::dbgs() << "  * Constraint failed\n";
+      }
+    });
+    assert((failed(rewriteResult) || constraintResults.size() == numResults) &&
+           "native PDL rewrite function returned "
+           "unexpected number of results");
+    // Populate memory either with the results or with 0s to preserve memory
+    // structure as expected
+    for (int i = 0; i < numResults; i++) {
+      memory[read()] = succeeded(rewriteResult)
+                           ? constraintResults[i].getAsOpaquePointer()
+                           : 0;
     }
     // Depending on the constraint jump to the proper destination.
     selectJump(succeeded(rewriteResult));

--- a/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
+++ b/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir
@@ -107,6 +107,29 @@ module @constraint_with_unused_result {
 
 // -----
 
+// CHECK-LABEL: module @constraint_with_result_multiple
+module @constraint_with_result_multiple {
+  // check that native constraints work as expected even when multiple identical constraints are fused  
+
+  // CHECK: func @matcher(%[[ROOT:.*]]: !pdl.operation)
+  // CHECK: %[[ATTR:.*]] = pdl_interp.apply_constraint "check_op_and_get_attr_constr"(%[[ROOT]]
+  // CHECK-NOT: pdl_interp.apply_constraint "check_op_and_get_attr_constr"
+  // CHECK: pdl_interp.record_match @rewriters::@pdl_generated_rewriter_0(%[[ROOT]], %[[ATTR]]  : !pdl.operation, !pdl.attribute)
+  // CHECK: pdl_interp.record_match @rewriters::@pdl_generated_rewriter(%[[ROOT]], %[[ATTR]] : !pdl.operation, !pdl.attribute)
+  pdl.pattern : benefit(1) {
+    %root = operation
+    %attr = pdl.apply_native_constraint "check_op_and_get_attr_constr"(%root : !pdl.operation) : !pdl.attribute
+    rewrite %root with "rewriter"(%attr : !pdl.attribute)
+  }
+  pdl.pattern : benefit(1) {
+    %root = operation
+    %attr = pdl.apply_native_constraint "check_op_and_get_attr_constr"(%root : !pdl.operation) : !pdl.attribute
+    rewrite %root with "rewriter"(%attr : !pdl.attribute)
+  }
+}
+
+// -----
+
 // CHECK-LABEL: module @inputs
 module @inputs {
   // CHECK: func @matcher(%[[ROOT:.*]]: !pdl.operation)


### PR DESCRIPTION
The `PDLToPDLInterp` pass tries to fuse common checks for multiple pdl patterns as much as possible. This PR fixes a bug where the fusion of multiple `pdl.apply_native_constraint` operations with results leads to incorrect pdl_interp code. This was due to the assumption that all uses of the results of a `pdl.apply_native_constraint` operation are known before the pass starts. This assumption was wrong as the pass may introduce more uses through fusion.

[This new test](https://github.com/Xilinx/llvm-project/blob/535f8a280d1373c2e44c9de2af20c0a43a45e9e9/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-matcher.mlir#L111) illustrates the now correct behavior.

This also fixes incorrect behavior of the bytecode interpreter in the context of constraints with results that are evaluated as false at matching time.