### PR TITLE
Support lowering tosa.custom_op to another dialect operation.

### DIFF
--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
@@ -506,6 +506,13 @@ createLinalgBodyCalculationForElementwiseOp(Operation *op, ValueRange args,
     }
   }
 
+  // tosa::CustomOp
+  if (auto customOp = dyn_cast<tosa::CustomOp>(op)) {
+    return llvm::StringSwitch<Value>(customOp.getIdentifierAttr().str())
+        .Case("atan2", rewriter.create<math::Atan2Op>(loc, resultTypes, args))
+        .Default(nullptr);
+  }
+
   (void)rewriter.notifyMatchFailure(
       op, "unhandled op for linalg body calculation for elementwise op");
   return nullptr;
@@ -2067,6 +2074,7 @@ void mlir::tosa::populateTosaToLinalgConversionPatterns(
       PointwiseConverter<tosa::FloorOp>,
       PointwiseConverter<tosa::ClampOp>,
       PointwiseConverter<tosa::SigmoidOp>,
+      PointwiseConverter<tosa::CustomOp>,
       IdentityNConverter<tosa::IdentityOp>,
       ReduceConverter<tosa::ReduceAllOp>,
       ReduceConverter<tosa::ReduceAnyOp>,


### PR DESCRIPTION
This should handle both static and dynamic shapes of operations.
For now, we only support `atan2` operations, but we can add more as we discover them.
There will be another PR that handles legalization from unsupported `torch.aten` operations to `tosa.custom_op` in the `torch-mlir` repo.