### PR TITLE
.github/workflows/mlir-tests.yml: Build main branches to populate ccache

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-# **DO NOT FILE A PULL REQUEST**
-
-This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.
-
-# **DO NOT FILE A PULL REQUEST**

--- a/.github/workflows/mlir-tests.yml
+++ b/.github/workflows/mlir-tests.yml
@@ -11,6 +11,9 @@ on:
       - 'mlir/**'
       - '.github/workflows/mlir-tests.yml'
       - '.github/workflows/llvm-project-tests.yml'
+  # Only builds on push populate the ccache that can be used by PRs
+  push:
+    branches: [ main, feature/fused-ops ]
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
Due to security (?) restrictions in github CI, PRs can only access the caches that were created by builds on the target branch (but not builds caused by sibiling PRs to the same target branch).
So we need to build the target branches (here: on every push, i.e. PR merge) to populate the caches.