### PR TITLE
fix native constraint op in mlir python bindings

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -666,8 +666,9 @@ OpFoldResult MulOp::fold(FoldAdaptor adaptor) {
   return mulBinaryFolder(lhsAttr, rhsAttr, resultTy, getShift());
 }
 
-OpFoldResult ReciprocalOp::fold(ArrayRef<Attribute> operands) {
-  auto constantAttr = dyn_cast_or_null<DenseElementsAttr>(operands[0]);
+OpFoldResult ReciprocalOp::fold(FoldAdaptor adaptor) {
+  
+  auto constantAttr = dyn_cast_or_null<DenseElementsAttr>(adaptor.getOperands()[0]);
   auto lhsTy = dyn_cast<RankedTensorType>(getInput1().getType());
 
   if (!lhsTy || !constantAttr) {
@@ -1025,7 +1026,7 @@ OpFoldResult TransposeOp::fold(FoldAdaptor adaptor) {
   return getInput1();
 }
 
-OpFoldResult ConcatOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ConcatOp::fold(FoldAdaptor adaptor) {
   // Fold consecutive concats on the same axis into a single op.
   // Keep track of the operands so we are able to construct a new concat
   // later. Conservatively assume that we double the number of operands when

--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -2823,7 +2823,8 @@ FailureOr<ast::OperationExpr *> Parser::createOperationExpr(
     OpResultTypeContext resultTypeContext,
     SmallVectorImpl<ast::Expr *> &operands,
     MutableArrayRef<ast::NamedAttributeDecl *> attributes,
-    SmallVectorImpl<ast::Expr *> &results) {
+    SmallVectorImpl<ast::Expr *> &results,
+    unsigned numRegions) {
   std::optional<StringRef> opNameRef = name->getName();
   const ods::Operation *odsOp = lookupODSOperation(opNameRef);
 

--- a/mlir/python/mlir/dialects/_pdl_ops_ext.py
+++ b/mlir/python/mlir/dialects/_pdl_ops_ext.py
@@ -58,13 +58,15 @@ class ApplyNativeConstraintOp:
 
   def __init__(self,
                name: Union[str, StringAttr],
+               results: Sequence[Type] = [],
                args: Sequence[Union[OpView, Operation, Value]] = [],
                *,
                loc=None,
                ip=None):
     name = _get_str_attr(name)
     args = _get_values(args)
-    super().__init__(name, args, loc=loc, ip=ip)
+    results = _get_values(results)
+    super().__init__(results, name, args, loc=loc, ip=ip)
 
 
 class ApplyNativeRewriteOp:


### PR DESCRIPTION
The python bindings for `ApplyNativeConstraintOp` were not aware of possible results of this operation.
Now they are