### PR TITLE
[MLIR][Tosa] TosaToTensor: create valid reshapes

### DIFF
--- a/mlir/lib/Conversion/TosaToTensor/TosaToTensor.cpp
+++ b/mlir/lib/Conversion/TosaToTensor/TosaToTensor.cpp
@@ -227,9 +227,10 @@ public:
         reshape.getLoc(),
         RankedTensorType::get(intermediateShape,
                               reshape.getType().getElementType()),
-        adaptor.getInput1());
-    Value expand =
-        rewriter.create<tosa::ReshapeOp>(reshape.getLoc(), resultTy, collapse);
+        adaptor.getInput1(), rewriter.getDenseI64ArrayAttr(intermediateShape));
+    Value expand = rewriter.create<tosa::ReshapeOp>(
+        reshape.getLoc(), resultTy, collapse,
+        rewriter.getDenseI64ArrayAttr(resultTy.getShape()));
     rewriter.replaceOp(reshape, expand);
 
     return success();


### PR DESCRIPTION
The pattern would create reshape ops without a newShape attr. This fails the verifier (which can be seen in the debug output; but curiously doesn't abort compilation),
and can cause crashes in other code that expect to see valid reshape ops, like ReshapeOp::fold.

Differential Revision: https://reviews.llvm.org/D154651