### PR TITLE
llvm/cmake/modules/AddLLVM.cmake: objlib: Preserve the SYSTEM property of include dirs of dependences

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -541,6 +541,10 @@ function(llvm_add_library name)
     # result in generating header files.  Add a dependendency so that
     # the generated header is created before this object library.
     if(ARG_LINK_LIBS)
+      # Link to LINK_LIBS to record which of their include directories
+      # are system directories. This information is not available in
+      # INCLUDE_DIRECTORIES property.
+      target_link_libraries(${obj_name} PRIVATE ${ARG_LINK_LIBS})
       cmake_parse_arguments(LINK_LIBS_ARG
         ""
         ""


### PR DESCRIPTION
This is important because third-party libraries like boost etc will have the SYSTEM property set by default on their include directories. This suppresses compiler warnings in their headers.
But doing
```
add_mlir_library( myLib
   my.cpp
   LINK_LIBS boost)
```
would `forget` the SYSTEM property on the boost include path and cause compiler warnings when building mylib.
When using warnings-as-errors, this will fail the build.