### PR TITLE
MLIR: Add option to print attributes on newlines

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -1096,6 +1096,10 @@ public:
   /// elements.
   OpPrintingFlags &elideLargeElementsAttrs(int64_t largeElementLimit = 16);
 
+  /// Enables breaking attributes on individual lines when there are more than
+  /// the given number of attributes on an operation.
+  OpPrintingFlags& newlineAfterAttribute(int64_t attributeLimit = 2);
+
   /// Enable or disable printing of debug information (based on `enable`). If
   /// 'prettyForm' is set to true, debug information is printed in a more
   /// readable 'pretty' form. Note: The IR generated with 'prettyForm' is not
@@ -1126,6 +1130,9 @@ public:
   /// Return the size limit for printing large ElementsAttr.
   std::optional<int64_t> getLargeElementsAttrLimit() const;
 
+  /// Return the size limit for printing newlines after attributes.
+  std::optional<unsigned> getNewlineAfterAttrLimit() const;
+
   /// Return if debug information should be printed.
   bool shouldPrintDebugInfo() const;
 
@@ -1151,6 +1158,10 @@ private:
   /// Elide large elements attributes if the number of elements is larger than
   /// the upper limit.
   std::optional<int64_t> elementsAttrElementLimit;
+
+  /// Print newlines after each attribute when an operation has more than
+  /// the given number of attributes.
+  std::optional<unsigned> newlineAfterAttr;
 
   /// Print debug information.
   bool printDebugInfoFlag : 1;

--- a/mlir/test/IR/mlir-newline-after-attr.mlir
+++ b/mlir/test/IR/mlir-newline-after-attr.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-opt %s -mlir-newline-after-attr=2 | FileCheck %s
+// Ensure that the printed version is still parseable.
+// RUN: mlir-opt %s -mlir-newline-after-attr=2 | mlir-opt
+
+// CHECK: foo.dense_attr =
+"test.op"() {foo.dense_attr = dense<1> : tensor<3xi32>} : () -> ()
+
+// CHECK: foo.dense_attr =
+// CHECK: foo.second_attr =
+"test.op"() {foo.dense_attr = dense<1> : tensor<3xi32>, foo.second_attr = dense<2> : tensor<3xi32>} : () -> ()


### PR DESCRIPTION
For operations that have many subgraphs, it makes the IR easier to read and makes reference differences easier to understand.