### PR TITLE
new tosa verifiers

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -422,6 +422,8 @@ def Tosa_SigmoidOp : Tosa_ElemWiseUnaryOp<"sigmoid"> {
   let results = (outs
     Tosa_Tensor:$output
   );
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1423,15 +1425,14 @@ def Tosa_ConcatOp : Tosa_Op<"concat", [
     static bool isCompatibleReturnTypes(TypeRange l, TypeRange r);
   }];
   let hasFolder = 1;
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
 // Operator: pad
 //===----------------------------------------------------------------------===//
 def Tosa_PadOp : Tosa_Op<"pad", [
-    DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-                              ["inferReturnTypeComponents"]>,
-    Pure]> {
+    InferTensorType, Pure]> {
   let summary = "Pads a tensor with value specified.";
 
   let description = [{
@@ -1470,6 +1471,14 @@ def Tosa_PadOp : Tosa_Op<"pad", [
 
   let hasCanonicalizer = 1;
   let hasFolder = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Returns true when two result types are compatible for this op;
+    /// Method used by InferTypeOpInterface.
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r);
+  }];
+
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -422,8 +422,6 @@ def Tosa_SigmoidOp : Tosa_ElemWiseUnaryOp<"sigmoid"> {
   let results = (outs
     Tosa_Tensor:$output
   );
-
-  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -1628,17 +1628,6 @@ LogicalResult WhileOp::inferReturnTypeComponents(
   return success();
 }
 
-LogicalResult SigmoidOp::verify() {
-  auto inputType = llvm::cast<ShapedType>(getInput().getType());
-  auto outputType = llvm::cast<ShapedType>(getOutput().getType());
-  auto result = verifyCompatibleShapes(inputType, outputType);
-  if (result.failed()) {
-    return emitOpError() << "input type " << inputType << " and output type "
-                         << outputType << " are not compatible";
-  }
-  return success();
-}
-
 std::optional<SmallVector<int64_t, 4>> ApplyScaleOp::getShapeForUnroll() {
   if (auto vt = llvm::dyn_cast<VectorType>(getType()))
     return llvm::to_vector<4>(vt.getShape());

--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -870,8 +870,8 @@ mlir::LogicalResult tosa::SliceOp::verify() {
                            << ") must match";
   }
   for (int64_t dim=0; dim < outputType.getRank(); ++dim) {
-    if (getSize()[dim] != -1 && !outputType.isDynamicDim(dim) &&
-        getSize()[dim] != outputType.getShape()[dim]) {
+        if (getSize()[dim] != -1 && !outputType.isDynamicDim(dim) &&
+            getSize()[dim] != outputType.getShape()[dim]) {
       return emitOpError() << "size attribute (" << getSize()[dim]
                            << ") does not match output type ("
                            << outputType.getShape()[dim] << ") in dimension "

--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -682,6 +682,10 @@ LogicalResult tosa::PadOp::inferReturnTypeComponents(
 
 LogicalResult PadOp::verify() {
   ShapedType inputType = llvm::cast<ShapedType>(getInput1().getType());
+  if (inputType.hasRank() && inputType.getRank() == 0) {
+    return emitOpError() << "input tensor rank must not be 0";
+  }
+
   ShapedType paddingType = llvm::cast<ShapedType>(getPadding().getType());
   if (paddingType.hasRank()) {
     if (paddingType.getRank() != 2) {

--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -100,8 +100,7 @@ Operation *TosaDialect::materializeConstant(OpBuilder &builder, Attribute value,
 // TOSA Operator Verifiers.
 //===----------------------------------------------------------------------===//
 
-template <typename T>
-static LogicalResult verifyConvOp(T op) {
+template <typename T> static LogicalResult verifyConvOp(T op) {
   // All TOSA conv ops have an input() and weight().
   auto inputType = llvm::dyn_cast<RankedTensorType>(op.getInput().getType());
   auto weightType = llvm::dyn_cast<RankedTensorType>(op.getWeight().getType());
@@ -508,7 +507,7 @@ LogicalResult ConcatOp::verify() {
   OperandRange inputs = getInput1();
 
   auto inputRank = ShapedType::kDynamic;
-  bool hasRankedInputs;
+  bool hasRankedInputs = false;
   for (auto input : inputs) {
     auto inputType = llvm::cast<ShapedType>(input.getType());
     if (inputType.hasRank()) {
@@ -834,18 +833,18 @@ mlir::LogicalResult tosa::ReshapeOp::verify() {
     }
 
     if ((int64_t)getNewShape().size() != outputType.getRank()) {
-      return emitOpError() << "rank of newShape (" << getNewShape().size()
-                           << ") and output (" << outputType.getRank()
+        return emitOpError() << "rank of newShape (" << getNewShape().size()
+                           << ") and output ("
+                           << outputType.getRank()
                            << ") must match";
     }
 
-    for (int64_t dim = 0; dim < outputType.getRank(); ++dim) {
-      if (getNewShape()[dim] != -1 &&
-          getNewShape()[dim] != outputType.getShape()[dim]) {
-        return emitOpError()
-               << "newShape attribute (" << getNewShape()[dim]
-               << ") does not match output type (" << outputType.getShape()[dim]
-               << ") in dimension " << dim;
+    for (int64_t dim=0; dim < outputType.getRank(); ++dim) {
+      if (getNewShape()[dim] != -1 && getNewShape()[dim] != outputType.getShape()[dim]) {
+        return emitOpError() << "newShape attribute (" << getNewShape()[dim]
+                            << ") does not match output type ("
+                            << outputType.getShape()[dim]
+                            << ") in dimension " << dim;
       }
     }
   }
@@ -859,16 +858,18 @@ mlir::LogicalResult tosa::SliceOp::verify() {
 
   if (inputType.getRank() != outputType.getRank()) {
     return emitOpError() << "rank of input (" << inputType.getRank()
-                         << ") and output (" << outputType.getRank()
-                         << ") must match";
+                           << ") and output ("
+                           << outputType.getRank()
+                           << ") must match";
   }
 
   if ((int64_t)getSize().size() != outputType.getRank()) {
-    return emitOpError() << "rank of size (" << getSize().size()
-                         << ") and output (" << outputType.getRank()
-                         << ") must match";
+        return emitOpError() << "rank of size (" << getSize().size()
+                           << ") and output ("
+                           << outputType.getRank()
+                           << ") must match";
   }
-  for (int64_t dim = 0; dim < outputType.getRank(); ++dim) {
+  for (int64_t dim=0; dim < outputType.getRank(); ++dim) {
     if (getSize()[dim] != -1 && !outputType.isDynamicDim(dim) &&
         getSize()[dim] != outputType.getShape()[dim]) {
       return emitOpError() << "size attribute (" << getSize()[dim]
@@ -879,14 +880,16 @@ mlir::LogicalResult tosa::SliceOp::verify() {
   }
 
   if ((int64_t)getStart().size() != inputType.getRank()) {
-    return emitOpError() << "rank of start (" << getStart().size()
-                         << ") and input (" << inputType.getRank()
-                         << ") must match";
+        return emitOpError() << "rank of start (" << getStart().size()
+                           << ") and input ("
+                           << inputType.getRank()
+                           << ") must match";
   }
   if ((int64_t)getSize().size() != inputType.getRank()) {
-    return emitOpError() << "rank of size (" << getSize().size()
-                         << ") and input (" << inputType.getRank()
-                         << ") must match";
+        return emitOpError() << "rank of size (" << getSize().size()
+                           << ") and input ("
+                           << inputType.getRank()
+                           << ") must match";
   }
 
   for (int i = 0; i < outputType.getRank(); ++i) {

--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -876,7 +876,7 @@ mlir::LogicalResult tosa::SliceOp::verify() {
                            << ") does not match output type ("
                            << outputType.getShape()[dim] << ") in dimension "
                            << dim;
-    }
+        }
   }
 
   if ((int64_t)getStart().size() != inputType.getRank()) {

--- a/mlir/test/Conversion/TosaToTensor/tosa-to-tensor.mlir
+++ b/mlir/test/Conversion/TosaToTensor/tosa-to-tensor.mlir
@@ -182,7 +182,7 @@ func.func @pad_dyn_input(%arg0 : tensor<?x2xf32>) -> (tensor<?x9xf32>) {
 }
 
 func.func @pad_dyn_padding(%arg0 : tensor<1x2xf32>) -> (tensor<?x9xf32>) {
-  %0 = arith.constant dense<[[-1, 2], [3, 4]]> : tensor<2x2xi32>
+  %0 = arith.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>
   // TODO: Output contains multiple "arith.constant 1 : index".
   // CHECK-DAG: [[INDEX1:%.+]] = arith.constant 1 : index
   // CHECK-DAG: [[INDEX2:%.+]] = arith.constant 2 : index

--- a/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/mlir/test/Dialect/Tosa/invalid.mlir
@@ -171,6 +171,22 @@ func.func @test_pad_negative_padding(%arg0: tensor<13x21xf32>) -> tensor<?x?xf32
 
 // -----
 
+func.func @test_pad_incorrect_input(%arg0: f32, %arg1: i32) -> f32 {
+  // expected-error@+1 {{'tosa.pad' op operand #0 must be ranked tensor of number values, but got 'f32'}}
+  %1 = "tosa.pad"(%arg0, %arg1) : (f32, i32) -> f32
+  return %1 : f32
+}
+
+// -----
+
+func.func @test_pad_zero_rank_input(%arg0: tensor<f32>, %arg1: tensor<i32>) -> tensor<f32> {
+  // expected-error@+1 {{'tosa.pad' op input tensor rank must not be 0}}
+  %1 = "tosa.pad"(%arg0, %arg1) : (tensor<f32>, tensor<i32>) -> tensor<f32>
+  return %1 : tensor<f32>
+}
+
+// -----
+
 func.func @test_transpose_non_const(%arg0: tensor<13x21x3xf32>, %arg1: tensor<3xi32>) -> tensor<3x13x21xf32> {
   // expected-error@+1 {{'tosa.transpose' op perms of transpose is not constant}}
   %0 = "tosa.transpose"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<3xi32>) -> tensor<3x13x21xf32>

--- a/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/mlir/test/Dialect/Tosa/invalid.mlir
@@ -171,14 +171,6 @@ func.func @test_pad_negative_padding(%arg0: tensor<13x21xf32>) -> tensor<?x?xf32
 
 // -----
 
-func.func @test_sigmoid_type_mismatch(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xi8> {
-  // expected-error@+1 {{'tosa.sigmoid' op requires the same element type for all operands and results}}
-  %0 = "tosa.sigmoid"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x4xi8>
-  return %0 : tensor<13x21x4xi8>
-}
-
-// -----
-
 func.func @test_transpose_non_const(%arg0: tensor<13x21x3xf32>, %arg1: tensor<3xi32>) -> tensor<3x13x21xf32> {
   // expected-error@+1 {{'tosa.transpose' op perms of transpose is not constant}}
   %0 = "tosa.transpose"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<3xi32>) -> tensor<3x13x21xf32>

--- a/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/mlir/test/Dialect/Tosa/invalid.mlir
@@ -179,14 +179,6 @@ func.func @test_sigmoid_type_mismatch(%arg0: tensor<13x21x3xf32>) -> tensor<13x2
 
 // -----
 
-func.func @test_sigmoid(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x4xf32> {
-  // expected-error@+1 {{'tosa.sigmoid' op input type 'tensor<13x21x3xf32>' and output type 'tensor<13x21x4xf32>' are not compatible}}
-  %0 = "tosa.sigmoid"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x4xf32>
-  return %0 : tensor<13x21x4xf32>
-}
-
-// -----
-
 func.func @test_transpose_non_const(%arg0: tensor<13x21x3xf32>, %arg1: tensor<3xi32>) -> tensor<3x13x21xf32> {
   // expected-error@+1 {{'tosa.transpose' op perms of transpose is not constant}}
   %0 = "tosa.transpose"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<3xi32>) -> tensor<3x13x21xf32>


### PR DESCRIPTION
Added missing verifiers for concat, pad as per the tosa spec. 
A brief list of cases covered in each verifier:

### concat
- Added verify method to cover the below checks
    - All inputs must have the same rank
    - Axis along which concatenation is to occur, in range from 0 to rank(shape)-1
- Added new test cases in invalid.mlir to validate
    - All inputs must have the same data type
    - Output shape and type must match inferred shape and type

### pad
- Added InferTensorType interface to Tosa_pad. This will run verification of the inferred output types
- Added verify method to test the padding tensor
    -  rank of padding tensor must be [rank(inputShape), 2]
    - each element in the padding tensor must be >= 0
- Added new test cases in invalid.mlir
