### PR TITLE
PDLL: Allow to implictly convert Tuple<Attr> with a single element to Attr

### DIFF
--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -766,6 +766,15 @@ LogicalResult Parser::convertTupleExpressionTo(
     return convertToRange({valueTy, valueRangeTy}, valueRangeTy);
   if (type == typeRangeTy)
     return convertToRange({typeTy, typeRangeTy}, typeRangeTy);
+  if (type == attrTy && exprType.size() == 1 &&
+      exprType.getElementTypes()[0] == type) {
+    // Parenthesis become tuples. Allow to unpack single element tuples
+    // to expressions.
+    expr = ast::MemberAccessExpr::create(ctx, expr->getLoc(), expr,
+                                         llvm::to_string(0),
+                                         exprType.getElementTypes()[0]);
+    return success();
+  }
 
   return emitErrorFn();
 }

--- a/mlir/test/mlir-pdll/Parser/expr-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr-failure.pdll
@@ -124,6 +124,16 @@ Pattern {
 
 // -----
 
+Constraint checkAttr(attr: Attr);
+Pattern {
+  let tuple = (result1 = value: Value);
+  // CHECK: unable to convert expression of type `Tuple<result1: Value>` to the expected type of `Attr`
+  checkAttr(tuple);
+  erase _: Op;
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // Range Expr
 //===----------------------------------------------------------------------===//

--- a/mlir/test/mlir-pdll/Parser/expr.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr.pdll
@@ -114,6 +114,20 @@ Pattern {
 
 // -----
 
+// Implicitly convert single element Tuple<Attr> to Attr
+// CHECK: Module
+// CHECK: `-MemberAccessExpr {{.*}} Member<0> Type<Attr>
+// CHECK:   `-TupleExpr {{.*}} Type<Tuple<Attr>>
+// CHECK:     `-AttributeExpr {{.*}} Value<"10: i32">
+Constraint checkAttr(attr: Attr);
+Pattern {
+  let tuple = (attr<"10: i32">);
+  checkAttr(tuple);
+  erase _: Op;
+}
+
+// -----
+
 #include "include/ops.td"
 
 // CHECK: Module


### PR DESCRIPTION
Parenthesis in PDLL are parsed as tuples. This conversion allows to use parenthesis in math expressions, so that `(a +b)` can be used as expression, allowing to write `(a + b) * c`.
Support for the actual math operators will come in a follow-up PR.