### PR TITLE
PDLL: Fix crash when logical not doesn't apply to call; prepare precedence

### DIFF
--- a/mlir/test/mlir-pdll/Parser/expr-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr-failure.pdll
@@ -216,6 +216,23 @@ Pattern {
 // -----
 
 Pattern {
+  // CHECK: expected native constraint
+  not attr<"0 : i1">
+  erase _;
+}
+
+// -----
+
+Pattern {
+  let tuple = (attr<"3 : i34">);
+  // CHECK: expected `(` after function name
+  not tuple.0;
+  erase _;
+}
+
+// -----
+
+Pattern {
   // CHECK: expected colon after integer literal
   let tuple = (10 = _: Value);
   erase op<>;


### PR DESCRIPTION
This creates precedence between expressions, preparing for all the expressions that will come later.

While doing this, I noticed that `!` has a bug when it's not followed by a function call. I added two tests and a check for that.