### PR TITLE
Revert wrong (?) diff to upstream

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
@@ -607,7 +607,7 @@ structured_op: !LinalgStructuredOpConfig
     value: !ScalarExpression
       scalar_fn:
         kind: binary
-        fn_name: div
+        fn_name: div_unsigned
         operands:
         - !ScalarExpression
           scalar_arg: lhs

--- a/mlir/test/Dialect/Linalg/generalize-named-ops.mlir
+++ b/mlir/test/Dialect/Linalg/generalize-named-ops.mlir
@@ -409,7 +409,7 @@ func.func @generalize_divu(%lhs: memref<7x14x21xi32>, %rhs: memref<7x14x21xi32>,
 // CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xi32>)
 
 // CHECK:         ^{{.+}}(%[[BBARG0:.+]]: i32, %[[BBARG1:.+]]: i32, %[[BBARG2:.+]]: i32)
-// CHECK-NEXT:      %[[DIVU:.+]] = arith.divsi %[[BBARG0]], %[[BBARG1]] : i32
+// CHECK-NEXT:      %[[DIVU:.+]] = arith.divui %[[BBARG0]], %[[BBARG1]] : i32
 // CHECK-NEXT:      linalg.yield %[[DIVU]] : i32
 
 // -----


### PR DESCRIPTION
This reduces our diff with upstream. I couldn't find any commit on our side that introduced this change, so maybe it was a merge conflict issue?