### PR TITLE
BF16 canonicalization of Pow + Reciprocal

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -89,8 +89,8 @@ struct SqrtReciprocalOptimization : public OpRewritePattern<tosa::PowOp> {
 
     auto constantType = scale.getElementType();
     float scaleValue = 0.;
-    if (constantType.isF32())
-      scaleValue = scale.getSplatValue<float>();
+    if (constantType.isF32() || constantType.isBF16())
+      scaleValue = scale.getSplatValue<llvm::APFloat>().convertToFloat();
     else
       return rewriter.notifyMatchFailure(op, "unexpected type for scale value of the pow op");
     if(scaleValue != 0.5)

--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -87,12 +87,7 @@ struct SqrtReciprocalOptimization : public OpRewritePattern<tosa::PowOp> {
     if (!scale.isSplat())
       return rewriter.notifyMatchFailure(op, "expected the pow scale to be a splat tensor");
 
-    auto constantType = scale.getElementType();
-    float scaleValue = 0.;
-    if (constantType.isF32() || constantType.isBF16())
-      scaleValue = scale.getSplatValue<llvm::APFloat>().convertToFloat();
-    else
-      return rewriter.notifyMatchFailure(op, "unexpected type for scale value of the pow op");
+    float scaleValue = scale.getSplatValue<llvm::APFloat>().convertToFloat();
     if(scaleValue != 0.5)
       return rewriter.notifyMatchFailure(op, "expected the pow to have a scale of 0.5 to be a sqrt");
 

--- a/mlir/test/Dialect/Tosa/canonicalize.mlir
+++ b/mlir/test/Dialect/Tosa/canonicalize.mlir
@@ -627,6 +627,18 @@ func.func @canonicalize_optimize_sqrt_reciprocal(%arg0: tensor<1x5x1x1xf32>) -> 
 
 // -----
 
+// CHECK-LABEL: @canonicalize_optimize_sqrt_reciprocal
+func.func @canonicalize_optimize_sqrt_reciprocal_bf16(%arg0: tensor<1x5x1x1xbf16>) -> tensor<1x5x1x1xbf16> {
+  // CHECK: %[[RSQRT:.*]] = tosa.rsqrt %arg{{.*}} : (tensor<1x5x1x1xbf16>) -> tensor<1x5x1x1xbf16>
+  // CHECK: return %[[RSQRT]] : tensor<1x5x1x1xbf16>
+  %0 = "tosa.const"() <{value = dense<5.000000e-01> : tensor<1x1x1x1xbf16>}> : () -> tensor<1x1x1x1xbf16>
+  %1 = tosa.pow %arg0, %0 : (tensor<1x5x1x1xbf16>, tensor<1x1x1x1xbf16>) -> tensor<1x5x1x1xbf16>
+  %2 = tosa.reciprocal %1 : (tensor<1x5x1x1xbf16>) -> tensor<1x5x1x1xbf16>
+  return %2 : tensor<1x5x1x1xbf16>
+}
+
+// -----
+
 // CHECK-LABEL: @canonicalize_optimize_sqrt_reciprocal_no_match
 func.func @canonicalize_optimize_sqrt_reciprocal_no_match(%arg0: tensor<1x5x1x1xf32>) -> tensor<1x5x1x1xf32> {
   // CHECK-NOT: tosa.rsqrt"(%arg{{.*}})


### PR DESCRIPTION
Allow for BF16 in the canonicalization of pow + reciprocal into rsqrt. 