### PR TITLE
feat: fold cast(cast(x)) to x when x and type of cast(cast) is the same.

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -868,9 +868,16 @@ OpFoldResult CastOp::fold(FoldAdaptor adaptor) {
     return getInput();
 
   // cast-to-iN(cast-to-iM(x)) -> cast-to-iN(x) when N <= M
+  // cast-to-iN(cast-to-iM(x)) -> x when N == type of x
   if (auto cast = getInput().getDefiningOp<CastOp>()) {
-    auto intermediateElTy = cast.getType().getElementType().dyn_cast<IntegerType>();
+    auto inputElTy =
+        cast.getInput().getType().getElementType().dyn_cast<IntegerType>();
     auto finalElTy = getType().getElementType().dyn_cast<IntegerType>();
+    if (inputElTy == finalElTy ) {
+      return cast.getInput();
+    }
+
+    auto intermediateElTy = cast.getType().getElementType().dyn_cast<IntegerType>();
     if (intermediateElTy && finalElTy &&
         intermediateElTy.getSignedness() == finalElTy.getSignedness() &&
         intermediateElTy.getWidth() >= finalElTy.getWidth()) {

--- a/mlir/test/Dialect/Tosa/canonicalize.mlir
+++ b/mlir/test/Dialect/Tosa/canonicalize.mlir
@@ -47,6 +47,22 @@ func.func @cast_fold_double(%arg0: tensor<?x1xf32>) -> tensor<?x1xi8> {
   return %1 : tensor<?x1xi8>
 }
 
+// CHECK-LABEL: @cast_fold_same_type
+func.func @cast_fold_same_type(%arg0: tensor<?x1xf32>) -> tensor<?x1xf32> {
+  // CHECK: return %arg0 : tensor<?x1xf32>
+  %0 = tosa.cast %arg0 : (tensor<?x1xf32>) -> tensor<?x1xi16>
+  %1 = tosa.cast %0 : (tensor<?x1xi16>) -> tensor<?x1xf32>
+  return %1 : tensor<?x1xf32>
+}
+
+// CHECK-LABEL: @cast_fold_same_type2
+func.func @cast_fold_same_type2(%arg0: tensor<?x1xi8>) -> tensor<?x1xi8> {
+  // CHECK: return %arg0 : tensor<?x1xi8>
+  %0 = tosa.cast %arg0 : (tensor<?x1xi8>) -> tensor<?x1xi1>
+  %1 = tosa.cast %0 : (tensor<?x1xi1>) -> tensor<?x1xi8>
+  return %1 : tensor<?x1xi8>
+}
+
 // CHECK-LABEL: @cast_no_fold_double1
 func.func @cast_no_fold_double1(%arg0: tensor<?x1xf32>) -> tensor<?x1xi8> {
   // CHECK: tosa.cast{{.*}} (tensor<?x1xf32>) -> tensor<?x1xui16>


### PR DESCRIPTION
Couldn't find any reason why that shouldn't be allowed. Is there any?
The idea is to fold cast(cast(x)) to x when types don't change between x and output of cast(cast).