### PR TITLE
CI: Enable PR action to check for proper code formatting

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -6,7 +6,6 @@ permissions:
 jobs:
   code_formatter:
     runs-on: ubuntu-latest
-    if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4


### PR DESCRIPTION
The action is from upstream LLVM, but it's disabled by default on forks. This PR enables it.


This shows that the action works: https://github.com/Xilinx/llvm-project/pull/123