### PR TITLE
[FXML-4320] Restrict types that are valid in EmitC

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
@@ -30,6 +30,8 @@
 namespace mlir {
 namespace emitc {
 void buildTerminatedBody(OpBuilder &builder, Location loc);
+/// Determines whether \p type is valid in EmitC.
+bool isValidEmitCType(mlir::Type type);
 /// Determines whether \p type is a valid integer type in EmitC.
 bool isSupportedIntegerType(mlir::Type type);
 /// Determines whether \p type is a valid floating-point type in EmitC.

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
@@ -31,7 +31,7 @@ namespace mlir {
 namespace emitc {
 void buildTerminatedBody(OpBuilder &builder, Location loc);
 /// Determines whether \p type is valid in EmitC.
-bool isValidEmitCType(mlir::Type type);
+bool isSupportedEmitCType(mlir::Type type);
 /// Determines whether \p type is a valid integer type in EmitC.
 bool isSupportedIntegerType(mlir::Type type);
 /// Determines whether \p type is a valid floating-point type in EmitC.

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -34,16 +34,16 @@ class EmitC_Op<string mnemonic, list<Trait> traits = []>
 // Base class for unary operations.
 class EmitC_UnaryOp<string mnemonic, list<Trait> traits = []> :
     EmitC_Op<mnemonic, traits> {
-  let arguments = (ins AnyType);
-  let results = (outs AnyType);
+  let arguments = (ins Valid_EmitC_Type);
+  let results = (outs Valid_EmitC_Type);
   let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
 // Base class for binary operations.
 class EmitC_BinaryOp<string mnemonic, list<Trait> traits = []> :
     EmitC_Op<mnemonic, traits> {
-  let arguments = (ins AnyType:$lhs, AnyType:$rhs);
-  let results = (outs AnyType);
+  let arguments = (ins Valid_EmitC_Type:$lhs, Valid_EmitC_Type:$rhs);
+  let results = (outs Valid_EmitC_Type);
   let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
@@ -97,9 +97,9 @@ def EmitC_ApplyOp : EmitC_Op<"apply", [CExpression]> {
   }];
   let arguments = (ins
     Arg<StrAttr, "the operator to apply">:$applicableOperator,
-    AnyType:$operand
+    Valid_EmitC_Type:$operand
   );
-  let results = (outs AnyType:$result);
+  let results = (outs Valid_EmitC_Type:$result);
   let assemblyFormat = [{
     $applicableOperator `(` $operand `)` attr-dict `:` functional-type($operand, results)
   }];
@@ -240,9 +240,9 @@ def EmitC_CallOpaqueOp : EmitC_Op<"call_opaque", [CExpression]> {
     Arg<StrAttr, "the C++ function to call">:$callee,
     Arg<OptionalAttr<ArrayAttr>, "the order of operands and further attributes">:$args,
     Arg<OptionalAttr<ArrayAttr>, "template arguments">:$template_args,
-    Variadic<AnyType>:$operands
+    Variadic<Valid_EmitC_Type>:$operands
   );
-  let results = (outs Variadic<AnyType>);
+  let results = (outs Variadic<Valid_EmitC_Type>);
   let builders = [
     OpBuilder<(ins
       "::mlir::TypeRange":$resultTypes,
@@ -284,15 +284,15 @@ def EmitC_CastOp : EmitC_Op<"cast",
     ```
   }];
 
-  let arguments = (ins AnyType:$source);
-  let results = (outs AnyType:$dest);
+  let arguments = (ins Valid_EmitC_Type:$source);
+  let results = (outs Valid_EmitC_Type:$dest);
   let assemblyFormat = "$source attr-dict `:` type($source) `to` type($dest)";
 }
 
 def EmitC_CmpOp : EmitC_BinaryOp<"cmp", [CExpression]> {
   let summary = "Comparison operation";
   let description = [{
-    With the `cmp` operation the comparison operators ==, !=, <, <=, >, >=, <=> 
+    With the `cmp` operation the comparison operators ==, !=, <, <=, >, >=, <=>
     can be applied.
 
     Its first argument is an attribute that defines the comparison operator:
@@ -309,7 +309,7 @@ def EmitC_CmpOp : EmitC_BinaryOp<"cmp", [CExpression]> {
     ```mlir
     // Custom form of the cmp operation.
     %0 = emitc.cmp eq, %arg0, %arg1 : (i32, i32) -> i1
-    %1 = emitc.cmp lt, %arg2, %arg3 : 
+    %1 = emitc.cmp lt, %arg2, %arg3 :
         (
           !emitc.opaque<"std::valarray<float>">,
           !emitc.opaque<"std::valarray<float>">
@@ -323,9 +323,9 @@ def EmitC_CmpOp : EmitC_BinaryOp<"cmp", [CExpression]> {
   }];
 
   let arguments = (ins EmitC_CmpPredicateAttr:$predicate,
-                       AnyType:$lhs,
-                       AnyType:$rhs);
-  let results = (outs AnyType);
+                       Valid_EmitC_Type:$lhs,
+                       Valid_EmitC_Type:$rhs);
+  let results = (outs Valid_EmitC_Type);
 
   let assemblyFormat = "$predicate `,` operands attr-dict `:` functional-type(operands, results)";
 }
@@ -354,7 +354,7 @@ def EmitC_ConstantOp : EmitC_Op<"constant", [ConstantLike]> {
   }];
 
   let arguments = (ins EmitC_OpaqueOrTypedAttr:$value);
-  let results = (outs AnyType);
+  let results = (outs Valid_EmitC_Type);
 
   let hasFolder = 1;
   let hasVerifier = 1;
@@ -424,7 +424,7 @@ def EmitC_ExpressionOp : EmitC_Op<"expression",
   }];
 
   let arguments = (ins UnitAttr:$do_not_inline);
-  let results = (outs AnyType:$result);
+  let results = (outs Valid_EmitC_Type:$result);
   let regions = (region SizedRegion<1>:$region);
 
   let hasVerifier = 1;
@@ -532,8 +532,8 @@ def EmitC_CallOp : EmitC_Op<"call",
     %2 = emitc.call @my_add(%0, %1) : (f32, f32) -> f32
     ```
   }];
-  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<AnyType>:$operands);
-  let results = (outs Variadic<AnyType>);
+  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<Valid_EmitC_Type>:$operands);
+  let results = (outs Variadic<Valid_EmitC_Type>);
 
   let builders = [
     OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
@@ -723,7 +723,7 @@ def EmitC_ReturnOp : EmitC_Op<"return", [Pure, HasParent<"FuncOp">,
     }
     ```
   }];
-  let arguments = (ins Optional<AnyType>:$operand);
+  let arguments = (ins Optional<Valid_EmitC_Type>:$operand);
 
   let assemblyFormat = "attr-dict ($operand^ `:` type($operand))?";
   let hasVerifier = 1;
@@ -767,7 +767,7 @@ def EmitC_LiteralOp : EmitC_Op<"literal", [Pure]> {
   }];
 
   let arguments = (ins StrAttr:$value);
-  let results = (outs AnyType:$result);
+  let results = (outs Valid_EmitC_Type:$result);
 
   let hasVerifier = 1;
   let assemblyFormat = "$value attr-dict `:` type($result)";
@@ -933,8 +933,8 @@ def EmitC_ConditionalOp : EmitC_Op<"conditional",
     int32_t v6 = v3 ? v4 : v5;
     ```
   }];
-  let arguments = (ins I1:$condition, AnyType:$true_value, AnyType:$false_value);
-  let results = (outs AnyType:$result);
+  let arguments = (ins I1:$condition, Valid_EmitC_Type:$true_value, Valid_EmitC_Type:$false_value);
+  let results = (outs Valid_EmitC_Type:$result);
   let assemblyFormat = "operands attr-dict `:` type($result)";
 }
 
@@ -1011,7 +1011,7 @@ def EmitC_VariableOp : EmitC_Op<"variable", []> {
   }];
 
   let arguments = (ins EmitC_OpaqueOrTypedAttr:$value);
-  let results = (outs AnyType);
+  let results = (outs Valid_EmitC_Type);
 
   let hasVerifier = 1;
 }
@@ -1108,7 +1108,7 @@ def EmitC_VerbatimOp : EmitC_Op<"verbatim"> {
     #endif
 
     ...
-    
+
     #ifdef __cplusplus
     }
     #endif
@@ -1139,7 +1139,7 @@ def EmitC_AssignOp : EmitC_Op<"assign", []> {
     ```
   }];
 
-  let arguments = (ins AnyType:$var, AnyType:$value);
+  let arguments = (ins Valid_EmitC_Type:$var, Valid_EmitC_Type:$value);
   let results = (outs);
 
   let hasVerifier = 1;
@@ -1160,7 +1160,7 @@ def EmitC_YieldOp : EmitC_Op<"yield",
     value is yielded.
   }];
 
-  let arguments = (ins Optional<AnyType>:$result);
+  let arguments = (ins Optional<Valid_EmitC_Type>:$result);
   let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
 
   let hasVerifier = 1;
@@ -1243,7 +1243,7 @@ def EmitC_SubscriptOp : EmitC_Op<"subscript",
   }];
   let arguments = (ins Arg<EmitC_ArrayType, "the reference to load from">:$array,
                        Variadic<IntegerIndexOrOpaqueType>:$indices);
-  let results = (outs AnyType:$result);
+  let results = (outs Valid_EmitC_Type:$result);
 
   let builders = [
     OpBuilder<(ins "Value":$array, "ValueRange":$indices), [{

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -292,7 +292,7 @@ def EmitC_CastOp : EmitC_Op<"cast",
 def EmitC_CmpOp : EmitC_BinaryOp<"cmp", [CExpression]> {
   let summary = "Comparison operation";
   let description = [{
-    With the `cmp` operation the comparison operators ==, !=, <, <=, >, >=, <=>
+    With the `cmp` operation the comparison operators ==, !=, <, <=, >, >=, <=> 
     can be applied.
 
     Its first argument is an attribute that defines the comparison operator:
@@ -309,7 +309,7 @@ def EmitC_CmpOp : EmitC_BinaryOp<"cmp", [CExpression]> {
     ```mlir
     // Custom form of the cmp operation.
     %0 = emitc.cmp eq, %arg0, %arg1 : (i32, i32) -> i1
-    %1 = emitc.cmp lt, %arg2, %arg3 :
+    %1 = emitc.cmp lt, %arg2, %arg3 : 
         (
           !emitc.opaque<"std::valarray<float>">,
           !emitc.opaque<"std::valarray<float>">
@@ -1108,7 +1108,7 @@ def EmitC_VerbatimOp : EmitC_Op<"verbatim"> {
     #endif
 
     ...
-
+    
     #ifdef __cplusplus
     }
     #endif

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -34,16 +34,16 @@ class EmitC_Op<string mnemonic, list<Trait> traits = []>
 // Base class for unary operations.
 class EmitC_UnaryOp<string mnemonic, list<Trait> traits = []> :
     EmitC_Op<mnemonic, traits> {
-  let arguments = (ins Valid_EmitC_Type);
-  let results = (outs Valid_EmitC_Type);
+  let arguments = (ins EmitCType);
+  let results = (outs EmitCType);
   let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
 // Base class for binary operations.
 class EmitC_BinaryOp<string mnemonic, list<Trait> traits = []> :
     EmitC_Op<mnemonic, traits> {
-  let arguments = (ins Valid_EmitC_Type:$lhs, Valid_EmitC_Type:$rhs);
-  let results = (outs Valid_EmitC_Type);
+  let arguments = (ins EmitCType:$lhs, EmitCType:$rhs);
+  let results = (outs EmitCType);
   let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 }
 
@@ -97,9 +97,9 @@ def EmitC_ApplyOp : EmitC_Op<"apply", [CExpression]> {
   }];
   let arguments = (ins
     Arg<StrAttr, "the operator to apply">:$applicableOperator,
-    Valid_EmitC_Type:$operand
+    EmitCType:$operand
   );
-  let results = (outs Valid_EmitC_Type:$result);
+  let results = (outs EmitCType:$result);
   let assemblyFormat = [{
     $applicableOperator `(` $operand `)` attr-dict `:` functional-type($operand, results)
   }];
@@ -240,9 +240,9 @@ def EmitC_CallOpaqueOp : EmitC_Op<"call_opaque", [CExpression]> {
     Arg<StrAttr, "the C++ function to call">:$callee,
     Arg<OptionalAttr<ArrayAttr>, "the order of operands and further attributes">:$args,
     Arg<OptionalAttr<ArrayAttr>, "template arguments">:$template_args,
-    Variadic<Valid_EmitC_Type>:$operands
+    Variadic<EmitCType>:$operands
   );
-  let results = (outs Variadic<Valid_EmitC_Type>);
+  let results = (outs Variadic<EmitCType>);
   let builders = [
     OpBuilder<(ins
       "::mlir::TypeRange":$resultTypes,
@@ -284,8 +284,8 @@ def EmitC_CastOp : EmitC_Op<"cast",
     ```
   }];
 
-  let arguments = (ins Valid_EmitC_Type:$source);
-  let results = (outs Valid_EmitC_Type:$dest);
+  let arguments = (ins EmitCType:$source);
+  let results = (outs EmitCType:$dest);
   let assemblyFormat = "$source attr-dict `:` type($source) `to` type($dest)";
 }
 
@@ -323,9 +323,9 @@ def EmitC_CmpOp : EmitC_BinaryOp<"cmp", [CExpression]> {
   }];
 
   let arguments = (ins EmitC_CmpPredicateAttr:$predicate,
-                       Valid_EmitC_Type:$lhs,
-                       Valid_EmitC_Type:$rhs);
-  let results = (outs Valid_EmitC_Type);
+                       EmitCType:$lhs,
+                       EmitCType:$rhs);
+  let results = (outs EmitCType);
 
   let assemblyFormat = "$predicate `,` operands attr-dict `:` functional-type(operands, results)";
 }
@@ -354,7 +354,7 @@ def EmitC_ConstantOp : EmitC_Op<"constant", [ConstantLike]> {
   }];
 
   let arguments = (ins EmitC_OpaqueOrTypedAttr:$value);
-  let results = (outs Valid_EmitC_Type);
+  let results = (outs EmitCType);
 
   let hasFolder = 1;
   let hasVerifier = 1;
@@ -424,7 +424,7 @@ def EmitC_ExpressionOp : EmitC_Op<"expression",
   }];
 
   let arguments = (ins UnitAttr:$do_not_inline);
-  let results = (outs Valid_EmitC_Type:$result);
+  let results = (outs EmitCType:$result);
   let regions = (region SizedRegion<1>:$region);
 
   let hasVerifier = 1;
@@ -532,8 +532,8 @@ def EmitC_CallOp : EmitC_Op<"call",
     %2 = emitc.call @my_add(%0, %1) : (f32, f32) -> f32
     ```
   }];
-  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<Valid_EmitC_Type>:$operands);
-  let results = (outs Variadic<Valid_EmitC_Type>);
+  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<EmitCType>:$operands);
+  let results = (outs Variadic<EmitCType>);
 
   let builders = [
     OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
@@ -723,7 +723,7 @@ def EmitC_ReturnOp : EmitC_Op<"return", [Pure, HasParent<"FuncOp">,
     }
     ```
   }];
-  let arguments = (ins Optional<Valid_EmitC_Type>:$operand);
+  let arguments = (ins Optional<EmitCType>:$operand);
 
   let assemblyFormat = "attr-dict ($operand^ `:` type($operand))?";
   let hasVerifier = 1;
@@ -767,7 +767,7 @@ def EmitC_LiteralOp : EmitC_Op<"literal", [Pure]> {
   }];
 
   let arguments = (ins StrAttr:$value);
-  let results = (outs Valid_EmitC_Type:$result);
+  let results = (outs EmitCType:$result);
 
   let hasVerifier = 1;
   let assemblyFormat = "$value attr-dict `:` type($result)";
@@ -933,8 +933,8 @@ def EmitC_ConditionalOp : EmitC_Op<"conditional",
     int32_t v6 = v3 ? v4 : v5;
     ```
   }];
-  let arguments = (ins I1:$condition, Valid_EmitC_Type:$true_value, Valid_EmitC_Type:$false_value);
-  let results = (outs Valid_EmitC_Type:$result);
+  let arguments = (ins I1:$condition, EmitCType:$true_value, EmitCType:$false_value);
+  let results = (outs EmitCType:$result);
   let assemblyFormat = "operands attr-dict `:` type($result)";
 }
 
@@ -1011,7 +1011,7 @@ def EmitC_VariableOp : EmitC_Op<"variable", []> {
   }];
 
   let arguments = (ins EmitC_OpaqueOrTypedAttr:$value);
-  let results = (outs Valid_EmitC_Type);
+  let results = (outs EmitCType);
 
   let hasVerifier = 1;
 }
@@ -1081,7 +1081,7 @@ def EmitC_GetGlobalOp : EmitC_Op<"get_global",
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$name);
-  let results = (outs AnyType:$result);
+  let results = (outs EmitCType:$result);
   let assemblyFormat = "$name `:` type($result) attr-dict";
 }
 
@@ -1139,7 +1139,7 @@ def EmitC_AssignOp : EmitC_Op<"assign", []> {
     ```
   }];
 
-  let arguments = (ins Valid_EmitC_Type:$var, Valid_EmitC_Type:$value);
+  let arguments = (ins EmitCType:$var, EmitCType:$value);
   let results = (outs);
 
   let hasVerifier = 1;
@@ -1160,7 +1160,7 @@ def EmitC_YieldOp : EmitC_Op<"yield",
     value is yielded.
   }];
 
-  let arguments = (ins Optional<Valid_EmitC_Type>:$result);
+  let arguments = (ins Optional<EmitCType>:$result);
   let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
 
   let hasVerifier = 1;
@@ -1243,7 +1243,7 @@ def EmitC_SubscriptOp : EmitC_Op<"subscript",
   }];
   let arguments = (ins Arg<EmitC_ArrayType, "the reference to load from">:$array,
                        Variadic<IntegerIndexOrOpaqueType>:$indices);
-  let results = (outs Valid_EmitC_Type:$result);
+  let results = (outs EmitCType:$result);
 
   let builders = [
     OpBuilder<(ins "Value":$array, "ValueRange":$indices), [{

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitCTypes.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitCTypes.td
@@ -22,6 +22,9 @@ include "mlir/IR/BuiltinTypeInterfaces.td"
 // EmitC type definitions
 //===----------------------------------------------------------------------===//
 
+def Valid_EmitC_Type : Type<CPred<"emitc::isValidEmitCType($_self)">,
+    "EmitC dialect type">;
+
 def EmitCIntegerType : Type<CPred<"emitc::isSupportedIntegerType($_self)">,
     "integer type supported by EmitC">;
 

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitCTypes.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitCTypes.td
@@ -22,8 +22,8 @@ include "mlir/IR/BuiltinTypeInterfaces.td"
 // EmitC type definitions
 //===----------------------------------------------------------------------===//
 
-def Valid_EmitC_Type : Type<CPred<"emitc::isValidEmitCType($_self)">,
-    "EmitC dialect type">;
+def EmitCType : Type<CPred<"emitc::isSupportedEmitCType($_self)">,
+    "type supported by EmitC">;
 
 def EmitCIntegerType : Type<CPred<"emitc::isSupportedIntegerType($_self)">,
     "integer type supported by EmitC">;

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -59,23 +59,24 @@ void mlir::emitc::buildTerminatedBody(OpBuilder &builder, Location loc) {
 }
 
 bool mlir::emitc::isSupportedEmitCType(Type type) {
-  if (isa<emitc::OpaqueType>(type)) {
+  if (llvm::isa<emitc::OpaqueType>(type)) {
     return true;
   }
-  if (auto ptrType = dyn_cast<emitc::PointerType>(type)) {
+  if (auto ptrType = llvm::dyn_cast<emitc::PointerType>(type)) {
     return isSupportedEmitCType(ptrType.getPointee());
   }
   if (auto arrayType = llvm::dyn_cast<emitc::ArrayType>(type)) {
     auto elemType = arrayType.getElementType();
-    return !isa<emitc::ArrayType>(elemType) && isSupportedEmitCType(elemType);
+    return !llvm::isa<emitc::ArrayType>(elemType) &&
+           isSupportedEmitCType(elemType);
   }
   if (type.isIndex()) {
     return true;
   }
-  if (isa<IntegerType>(type)) {
+  if (llvm::isa<IntegerType>(type)) {
     return isSupportedIntegerType(type);
   }
-  if (auto floatType = llvm::dyn_cast<FloatType>(type)) {
+  if (llvm::isa<FloatType>(type)) {
     return isSupportedFloatType(type);
   }
   if (auto tensorType = llvm::dyn_cast<TensorType>(type)) {
@@ -83,14 +84,14 @@ bool mlir::emitc::isSupportedEmitCType(Type type) {
       return false;
     }
     auto elemType = tensorType.getElementType();
-    if (isa<emitc::ArrayType>(elemType)) {
+    if (llvm::isa<emitc::ArrayType>(elemType)) {
       return false;
     }
     return isSupportedEmitCType(elemType);
   }
   if (auto tupleType = llvm::dyn_cast<TupleType>(type)) {
     return llvm::all_of(tupleType.getTypes(), [](Type type) {
-      return !isa<emitc::ArrayType>(type) && isSupportedEmitCType(type);
+      return !llvm::isa<emitc::ArrayType>(type) && isSupportedEmitCType(type);
     });
   }
   return false;

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -59,26 +59,21 @@ void mlir::emitc::buildTerminatedBody(OpBuilder &builder, Location loc) {
 }
 
 bool mlir::emitc::isSupportedEmitCType(Type type) {
-  if (llvm::isa<emitc::OpaqueType>(type)) {
+  if (llvm::isa<emitc::OpaqueType>(type))
     return true;
-  }
-  if (auto ptrType = llvm::dyn_cast<emitc::PointerType>(type)) {
+  if (auto ptrType = llvm::dyn_cast<emitc::PointerType>(type))
     return isSupportedEmitCType(ptrType.getPointee());
-  }
   if (auto arrayType = llvm::dyn_cast<emitc::ArrayType>(type)) {
     auto elemType = arrayType.getElementType();
     return !llvm::isa<emitc::ArrayType>(elemType) &&
            isSupportedEmitCType(elemType);
   }
-  if (type.isIndex()) {
+  if (type.isIndex())
     return true;
-  }
-  if (llvm::isa<IntegerType>(type)) {
+  if (llvm::isa<IntegerType>(type))
     return isSupportedIntegerType(type);
-  }
-  if (llvm::isa<FloatType>(type)) {
+  if (llvm::isa<FloatType>(type))
     return isSupportedFloatType(type);
-  }
   if (auto tensorType = llvm::dyn_cast<TensorType>(type)) {
     if (!tensorType.hasStaticShape()) {
       return false;

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -58,16 +58,16 @@ void mlir::emitc::buildTerminatedBody(OpBuilder &builder, Location loc) {
   builder.create<emitc::YieldOp>(loc);
 }
 
-bool mlir::emitc::isValidEmitCType(Type type) {
+bool mlir::emitc::isSupportedEmitCType(Type type) {
   if (isa<emitc::OpaqueType>(type)) {
     return true;
   }
   if (auto ptrType = dyn_cast<emitc::PointerType>(type)) {
-    return isValidEmitCType(ptrType.getPointee());
+    return isSupportedEmitCType(ptrType.getPointee());
   }
   if (auto arrayType = llvm::dyn_cast<emitc::ArrayType>(type)) {
     auto elemType = arrayType.getElementType();
-    return !isa<emitc::ArrayType>(elemType) && isValidEmitCType(elemType);
+    return !isa<emitc::ArrayType>(elemType) && isSupportedEmitCType(elemType);
   }
   if (type.isIndex()) {
     return true;
@@ -86,11 +86,11 @@ bool mlir::emitc::isValidEmitCType(Type type) {
     if (isa<emitc::ArrayType>(elemType)) {
       return false;
     }
-    return isValidEmitCType(elemType);
+    return isSupportedEmitCType(elemType);
   }
   if (auto tupleType = llvm::dyn_cast<TupleType>(type)) {
     return llvm::all_of(tupleType.getTypes(), [](Type type) {
-      return !isa<emitc::ArrayType>(type) && isValidEmitCType(type);
+      return !isa<emitc::ArrayType>(type) && isSupportedEmitCType(type);
     });
   }
   return false;

--- a/mlir/test/Dialect/EmitC/invalid_types.mlir
+++ b/mlir/test/Dialect/EmitC/invalid_types.mlir
@@ -97,3 +97,51 @@ func.func @illegal_float_type(%arg0: f80, %arg1: f80) {
     %mul = "emitc.mul" (%arg0, %arg1) : (f80, f80) -> f80
     return
 }
+
+// -----
+
+func.func @illegal_pointee_type() {
+    // expected-error @+1 {{'emitc.variable' op result #0 must be type supported by EmitC, but got '!emitc.ptr<i11>'}}
+    %v = "emitc.variable"(){value = #emitc.opaque<"">} : () -> !emitc.ptr<i11>
+    return
+}
+
+// -----
+
+func.func @illegal_non_static_tensor_shape_type() {
+    // expected-error @+1 {{'emitc.variable' op result #0 must be type supported by EmitC, but got 'tensor<?xf32>'}}
+    %v = "emitc.variable"(){value = #emitc.opaque<"">} : () -> tensor<?xf32>
+    return
+}
+
+// -----
+
+func.func @illegal_tensor_array_element_type() {
+    // expected-error @+1 {{'emitc.variable' op result #0 must be type supported by EmitC, but got 'tensor<!emitc.array<9xi16>>'}}
+    %v = "emitc.variable"(){value = #emitc.opaque<"">} : () -> tensor<!emitc.array<9xi16>>
+    return
+}
+
+// -----
+
+func.func @illegal_tensor_integer_element_type() {
+    // expected-error @+1 {{'emitc.variable' op result #0 must be type supported by EmitC, but got 'tensor<9xi11>'}}
+    %v = "emitc.variable"(){value = #emitc.opaque<"">} : () -> tensor<9xi11>
+    return
+}
+
+// -----
+
+func.func @illegal_tuple_array_element_type() {
+    // expected-error @+1 {{'emitc.variable' op result #0 must be type supported by EmitC, but got 'tuple<!emitc.array<9xf32>, f32>'}}
+    %v = "emitc.variable"(){value = #emitc.opaque<"">} : () -> tuple<!emitc.array<9xf32>, f32>
+    return
+}
+
+// -----
+
+func.func @illegal_tuple_float_element_type() {
+    // expected-error @+1 {{'emitc.variable' op result #0 must be type supported by EmitC, but got 'tuple<i32, f80>'}}
+    %v = "emitc.variable"(){value = #emitc.opaque<"">} : () -> tuple<i32, f80>
+    return
+}


### PR DESCRIPTION
Use what is currently supported by the emitter to restrict the valid types of EmitC operations. Define utility function for valid types, such that they can be used to restrict the operations in the table gen as well as being available for reuse in dialect conversions.