### PR TITLE
[FXML-4281] Fix signedness behavior of unsigned integer <-> floating-point conversions

### DIFF
--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -234,7 +234,16 @@ public:
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast destination type");
 
-    rewriter.replaceOpWithNewOp<emitc::CastOp>(castOp, dstType,
+    // Convert to unsigned if it's the "ui" variant
+    // Signless is interpreted as signed, so no need to cast for "si"
+    Type actualResultType = dstType;
+    if (isa<arith::FPToUIOp>(castOp)) {
+      actualResultType =
+          rewriter.getIntegerType(operandType.getIntOrFloatBitWidth(),
+                                  /*isSigned=*/false);
+    }
+
+    rewriter.replaceOpWithNewOp<emitc::CastOp>(castOp, actualResultType,
                                                adaptor.getOperands());
 
     return success();

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -272,6 +272,7 @@ public:
     Location loc = castOp.getLoc();
 
     // Vectors in particular are not supported
+    // (see use of front() below)
     Type operandType = adaptor.getIn().getType();
     if (!emitc::isSupportedIntegerType(operandType))
       return rewriter.notifyMatchFailure(castOp,
@@ -289,9 +290,6 @@ public:
 
     // Convert to unsigned if it's the "ui" variant
     // Signless is interpreted as signed, so no need to cast for "si"
-
-    // Note this needs to be changed to handle vectors
-    // (won't show up until these are supported EmitC types though)
     Value castSource = opers.front();
     if (isa<arith::UIToFPOp>(castOp))
       castSource = castSignlessToUnsigned(rewriter, loc, castSource);

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-cast-truncate.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-cast-truncate.mlir
@@ -13,7 +13,8 @@ func.func @arith_float_to_int_cast_ops(%arg0: f32, %arg1: f64) {
   // CHECK: emitc.cast %arg1 : f64 to i16
   %3 = arith.fptosi %arg1 : f64 to i16
 
-  // CHECK: emitc.cast %arg0 : f32 to ui32
+  // CHECK: %[[CAST0:.*]] = emitc.cast %arg0 : f32 to ui32
+  // CHECK: emitc.cast %[[CAST0]] : ui32 to i32
   %4 = arith.fptoui %arg0 : f32 to i32
   
   return

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-cast-truncate.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-cast-truncate.mlir
@@ -13,7 +13,7 @@ func.func @arith_float_to_int_cast_ops(%arg0: f32, %arg1: f64) {
   // CHECK: emitc.cast %arg1 : f64 to i16
   %3 = arith.fptosi %arg1 : f64 to i16
 
-  // CHECK: emitc.cast %arg0 : f32 to i32
+  // CHECK: emitc.cast %arg0 : f32 to ui32
   %4 = arith.fptoui %arg0 : f32 to i32
   
   return

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -162,12 +162,10 @@ func.func @arith_cmpf_ogt(%arg0: f32, %arg1: f32) -> i1 {
 // -----
 
 func.func @arith_int_to_float_cast_ops(%arg0: i8, %arg1: i64) {
-  // CHECK: %[[CAST_SI8:.*]] = emitc.cast %arg0 : i8 to si8
-  // CHECK: emitc.cast %[[CAST_SI8]] : si8 to f32
+  // CHECK: emitc.cast %arg0 : i8 to f32
   %0 = arith.sitofp %arg0 : i8 to f32
 
-  // CHECK: %[[CAST_SI64:.*]] = emitc.cast %arg1 : i64 to si64
-  // CHECK: emitc.cast %[[CAST_SI64]] : si64 to f32
+  // CHECK: emitc.cast %arg1 : i64 to f32
   %1 = arith.sitofp %arg1 : i64 to f32
 
   // CHECK: %[[CAST_UNS:.*]] = emitc.cast %arg0 : i8 to ui8

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -162,13 +162,16 @@ func.func @arith_cmpf_ogt(%arg0: f32, %arg1: f32) -> i1 {
 // -----
 
 func.func @arith_int_to_float_cast_ops(%arg0: i8, %arg1: i64) {
-  // CHECK: emitc.cast %arg0 : i8 to f32
+  // CHECK: %[[CAST_SI8:.*]] = emitc.cast %arg0 : i8 to si8
+  // CHECK: emitc.cast %[[CAST_SI8]] : si8 to f32
   %0 = arith.sitofp %arg0 : i8 to f32
 
-  // CHECK: emitc.cast %arg1 : i64 to f32
+  // CHECK: %[[CAST_SI64:.*]] = emitc.cast %arg1 : i64 to si64
+  // CHECK: emitc.cast %[[CAST_SI64]] : si64 to f32
   %1 = arith.sitofp %arg1 : i64 to f32
 
-  // CHECK: emitc.cast %arg0 : i8 to f32
+  // CHECK: %[[CAST_UNS:.*]] = emitc.cast %arg0 : i8 to ui8
+  // CHECK: emitc.cast %[[CAST_UNS]] : ui8 to f32
   %2 = arith.uitofp %arg0 : i8 to f32
 
   return


### PR DESCRIPTION
This PR fixes the behavior of int-to-float conversions, by issuing an explicit cast to signed or unsigned when the source type (in MLIR) is a signless integer. Thanks @josel-amd for pointing this out!