### PR TITLE
PDLL native operator abs

### DIFF
--- a/mlir/include/mlir/Dialect/PDL/IR/Builtins.h
+++ b/mlir/include/mlir/Dialect/PDL/IR/Builtins.h
@@ -37,6 +37,7 @@ enum class BinaryOpKind {
 enum class UnaryOpKind {
   log2,
   exp2,
+  abs,
 };
 
 LogicalResult createDictionaryAttr(PatternRewriter &rewriter,
@@ -48,9 +49,6 @@ LogicalResult addEntryToDictionaryAttr(PatternRewriter &rewriter,
 Attribute createArrayAttr(PatternRewriter &rewriter);
 Attribute addElemToArrayAttr(PatternRewriter &rewriter, Attribute attr,
                              Attribute element);
-template <BinaryOpKind T>
-LogicalResult binaryOp(PatternRewriter &rewriter, PDLResultList &results,
-                       llvm::ArrayRef<PDLValue> args);
 LogicalResult mul(PatternRewriter &rewriter, PDLResultList &results,
                   llvm::ArrayRef<PDLValue> args);
 LogicalResult div(PatternRewriter &rewriter, PDLResultList &results,
@@ -65,10 +63,8 @@ LogicalResult log2(PatternRewriter &rewriter, PDLResultList &results,
                    llvm::ArrayRef<PDLValue> args);
 LogicalResult exp2(PatternRewriter &rewriter, PDLResultList &results,
                    llvm::ArrayRef<PDLValue> args);
-
-template <BinaryOpKind T>
-LogicalResult binaryOp(PatternRewriter &rewriter, PDLResultList &results,
-                       llvm::ArrayRef<PDLValue> args);
+LogicalResult abs(PatternRewriter &rewriter, PDLResultList &results,
+                  llvm::ArrayRef<PDLValue> args);
 } // namespace builtin
 } // namespace pdl
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/PDL/IR/Builtins.h
+++ b/mlir/include/mlir/Dialect/PDL/IR/Builtins.h
@@ -28,16 +28,16 @@ void registerBuiltins(PDLPatternModule &pdlPattern);
 namespace builtin {
 enum class BinaryOpKind {
   add,
-  sub,
-  mul,
   div,
   mod,
+  mul,
+  sub,
 };
 
 enum class UnaryOpKind {
-  log2,
-  exp2,
   abs,
+  exp2,
+  log2,
 };
 
 LogicalResult createDictionaryAttr(PatternRewriter &rewriter,

--- a/mlir/lib/Dialect/PDL/IR/Builtins.cpp
+++ b/mlir/lib/Dialect/PDL/IR/Builtins.cpp
@@ -1,6 +1,5 @@
 #include <cassert>
 #include <cstdint>
-#include <iostream>
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/APSInt.h>
@@ -112,16 +111,8 @@ LogicalResult static unaryOp(PatternRewriter &rewriter, PDLResultList &results,
         return success();
       }
       if (integerType.isSignless()) {
-        auto resultVal = rewriter.getIntegerAttr(
-            integerType, std::abs(operandIntAttr.getInt()));
         results.push_back(rewriter.getIntegerAttr(
             integerType, std::abs(operandIntAttr.getInt())));
-
-        std::cout << "Input: "
-                  << (uint8_t)operandIntAttr.getValue().getZExtValue()
-                  << std::endl;
-        std::cout << "Result store in IntegerAttr: " << resultVal.getInt()
-                  << std::endl;
         return success();
       }
       // If unsigned, don't do anything

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
@@ -377,6 +377,7 @@ Token Lexer::lexIdentifier(const char *tokStart) {
                          .Case("_", Token::underscore)
                          .Case("log2", Token::log2)
                          .Case("exp2", Token::exp2)
+                         .Case("abs", Token::abs)
                          .Default(Token::identifier);
   return Token(kind, str);
 }

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.h
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.h
@@ -80,15 +80,18 @@ public:
     equal,
     equal_arrow,
     semicolon,
-    /// Paired punctuation.
-    add,
-    sub,
-    mul,
-    div,
-    mod,
-    log2,
-    exp2,
+
+    /// Arithmetic.
     abs,
+    add,
+    div,
+    exp2,
+    log2,
+    mod,
+    mul,
+    sub,
+
+    /// Paired punctuation.
     less,
     greater,
     l_brace,

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.h
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.h
@@ -81,11 +81,11 @@ public:
     equal_arrow,
     semicolon,
     /// Paired punctuation.
+    add,
+    sub,
     mul,
     div,
     mod,
-    add,
-    sub,
     log2,
     exp2,
     abs,

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.h
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.h
@@ -88,6 +88,7 @@ public:
     sub,
     log2,
     exp2,
+    abs,
     less,
     greater,
     l_brace,

--- a/mlir/test/mlir-pdll-lsp-server/completion.test
+++ b/mlir/test/mlir-pdll-lsp-server/completion.test
@@ -208,6 +208,12 @@
 // CHECK-NEXT:        "kind": 8,
 // CHECK-NEXT:        "label": "__builtin_log2Constraint",
 // CHECK-NEXT:        "sortText": "2___builtin_log2Constraint"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "detail": "(Attr: Attr) -> Attr",
+// CHECK-NEXT:        "kind": 8,
+// CHECK-NEXT:        "label": "__builtin_absConstraint",
+// CHECK-NEXT:        "sortText": "2___builtin_absConstraint"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ]
 // CHECK-NEXT:  }

--- a/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
+++ b/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
@@ -309,6 +309,7 @@ Pattern TestAdd {
 // CHECK:            apply_native_constraint "__builtin_modConstraint"(%[[VAL_0]], %[[VAL_1]] : !pdl.attribute, !pdl.attribute) : !pdl.attribute
 // CHECK:            apply_native_constraint "__builtin_log2Constraint"(%[[VAL_0]] : !pdl.attribute) : !pdl.attribute
 // CHECK:            apply_native_constraint "__builtin_exp2Constraint"(%[[VAL_0]] : !pdl.attribute) : !pdl.attribute
+// CHECK:            apply_native_constraint "__builtin_absConstraint"(%[[VAL_0]] : !pdl.attribute) : !pdl.attribute
 
 Pattern TestOperatorsNotInRewriteSection {
   let a : Attr = attr<"4 : i32">;
@@ -320,6 +321,7 @@ Pattern TestOperatorsNotInRewriteSection {
   let modConstraint : Attr = a % b;
   let log2Constraint : Attr = log2(a);
   let exp2Constraint : Attr = exp2(a);
+  let absConstraint : Attr = abs(a);
   replace op<test.simple> with op<test.success>;
 }
 
@@ -336,6 +338,7 @@ Pattern TestOperatorsNotInRewriteSection {
 // CHECK:              apply_native_rewrite "__builtin_modRewrite"(%[[VAL_0]], %[[VAL_1]] : !pdl.attribute, !pdl.attribute) : !pdl.attribute
 // CHECK:              apply_native_rewrite "__builtin_log2Rewrite"(%[[VAL_0]] : !pdl.attribute) : !pdl.attribute
 // CHECK:              apply_native_rewrite "__builtin_exp2Rewrite"(%[[VAL_0]] : !pdl.attribute) : !pdl.attribute
+// CHECK:              apply_native_rewrite "__builtin_absRewrite"(%[[VAL_0]] : !pdl.attribute) : !pdl.attribute
 Pattern TestOperatorsInRewriteSection {
   let root = op<>(operand: Value, operands: ValueRange) -> (type: Type, types: TypeRange);
   rewrite root with {
@@ -348,6 +351,7 @@ Pattern TestOperatorsInRewriteSection {
     let modRewrite : Attr = a % b;
     let log2Rewrite : Attr = log2(a);
     let exp2Rewrite : Attr = exp2(a);
+    let absRewrite : Attr = abs(a);
     erase root;
   };
 }

--- a/mlir/test/mlir-pdll/Parser/expr-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr-failure.pdll
@@ -581,6 +581,17 @@ Pattern {
 
 // -----
 
+Pattern {
+  // CHECK: cannot evaluate abs operator in rewrite section. Assign to a variable with `let`
+  let root = op<>(operand: Value, operands: ValueRange) -> (type: Type, types: TypeRange);
+  rewrite root with {
+    abs(attr<"-4 : si32">);
+    erase root;
+  };
+}
+
+// -----
+
 // check llvm::saveAndRestore works
 Pattern {
   // CHECK: cannot evaluate exp2 operator in rewrite section. Assign to a variable with `let`
@@ -588,6 +599,32 @@ Pattern {
   rewrite root with {
     let a : Attr = attr<"4 : i32"> + attr<"5 : i32">;
     exp2(attr<"4 : i32">);
+    erase root;
+  };
+}
+
+// -----
+
+// check llvm::saveAndRestore works
+Pattern {
+  // CHECK: cannot evaluate log2 operator in rewrite section. Assign to a variable with `let`
+  let root = op<>(operand: Value, operands: ValueRange) -> (type: Type, types: TypeRange);
+  rewrite root with {
+    let a : Attr = attr<"4 : i32"> + attr<"5 : i32">;
+    log2(attr<"4 : i32">);
+    erase root;
+  };
+}
+
+// -----
+
+// check llvm::saveAndRestore works
+Pattern {
+  // CHECK: cannot evaluate abs operator in rewrite section. Assign to a variable with `let`
+  let root = op<>(operand: Value, operands: ValueRange) -> (type: Type, types: TypeRange);
+  rewrite root with {
+    let a : Attr = attr<"4 : i32"> + attr<"5 : i32">;
+    abs(attr<"4 : i32">);
     erase root;
   };
 }

--- a/mlir/test/mlir-pdll/Parser/expr.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr.pdll
@@ -450,6 +450,7 @@ Pattern {
 // CHECK: UserConstraintDecl {{.*}} Name<__builtin_modConstraint> ResultType<Attr>
 // CHECK: UserConstraintDecl {{.*}} Name<__builtin_log2Constraint> ResultType<Attr>
 // CHECK: UserConstraintDecl {{.*}} Name<__builtin_exp2Constraint> ResultType<Attr>
+// CHECK: UserConstraintDecl {{.*}} Name<__builtin_absConstraint> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_addRewrite> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_subRewrite> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_mulRewrite> ResultType<Attr>
@@ -457,15 +458,19 @@ Pattern {
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_modRewrite> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_log2Rewrite> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_exp2Rewrite> ResultType<Attr>
+// CHECK: UserRewriteDecl {{.*}} Name<__builtin_absRewrite> ResultType<Attr>
 Pattern {
   let root = op<>(operand: Value, operands: ValueRange) -> (type: Type, types: TypeRange);
-  let addConstraint : Attr = attr<"4 : i32"> + attr<"5 : i32">;
-  let subConstraint : Attr = attr<"4 : i32"> - attr<"5 : i32">;
-  let mulConstraint : Attr = attr<"4 : i32"> * attr<"5 : i32">;
-  let divConstraint : Attr = attr<"4 : i32"> / attr<"5 : i32">;
-  let modConstraint : Attr = attr<"4 : i32"> % attr<"5 : i32">;
-  let log2Constraint : Attr = log2(attr<"4 : i32">);
-  let exp2Constraint : Attr = exp2(attr<"4 : i32">);
+  let a : Attr = attr<"4 : i32">;
+  let b : Attr = attr<"5 : i32">;
+  let addConstraint : Attr = a + b;
+  let subConstraint : Attr = a - b;
+  let mulConstraint : Attr = a * b;
+  let divConstraint : Attr = a / b;
+  let modConstraint : Attr = a % b;
+  let log2Constraint : Attr = log2(a);
+  let exp2Constraint : Attr = exp2(b);
+  let absConstraint : Attr = abs(attr<"-4 : si32">);
   rewrite root with {
     let addRewrite : Attr = attr<"4 : i32"> + attr<"5 : i32">;
     let subRewrite : Attr = attr<"4 : i32"> - attr<"5 : i32">;
@@ -474,6 +479,7 @@ Pattern {
     let modRewrite : Attr = attr<"4 : i32"> % attr<"5 : i32">;
     let log2Rewrite : Attr = log2(attr<"4 : i32">);
     let exp2Rewrite : Attr = exp2(attr<"4 : i32">);
+    let absRewrite : Attr = abs(attr<"-4 : si32">);
     erase root;
   };
 }
@@ -488,6 +494,7 @@ Pattern {
 // CHECK: UserConstraintDecl {{.*}} Name<__builtin_modConstraint> ResultType<Attr>
 // CHECK: UserConstraintDecl {{.*}} Name<__builtin_log2Constraint> ResultType<Attr>
 // CHECK: UserConstraintDecl {{.*}} Name<__builtin_exp2Constraint> ResultType<Attr>
+// CHECK: UserConstraintDecl {{.*}} Name<__builtin_absConstraint> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_addRewrite> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_subRewrite> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_mulRewrite> ResultType<Attr>
@@ -495,6 +502,7 @@ Pattern {
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_modRewrite> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_log2Rewrite> ResultType<Attr>
 // CHECK: UserRewriteDecl {{.*}} Name<__builtin_exp2Rewrite> ResultType<Attr>
+// CHECK: UserRewriteDecl {{.*}} Name<__builtin_absRewrite> ResultType<Attr>
 Constraint TestConstraint(attr: Attr, op: Op, type: Type, value: Value, typeRange: TypeRange, valueRange: ValueRange) {
   let a : Attr = attr<"4 : i32">;
   let b : Attr = attr<"5 : i32">;
@@ -505,6 +513,7 @@ Constraint TestConstraint(attr: Attr, op: Op, type: Type, value: Value, typeRang
   let modConstraint : Attr = a % b;
   let log2Constraint : Attr = log2(a);
   let exp2Constraint : Attr = exp2(b);
+  let absConstraint : Attr = abs(attr<"-4 : si32">);
 }
 
 Rewrite TestRewrite(attr: Attr, op: Op, type: Type, value: Value, typeRange: TypeRange, valueRange: ValueRange) {
@@ -517,6 +526,7 @@ Rewrite TestRewrite(attr: Attr, op: Op, type: Type, value: Value, typeRange: Typ
   let modRewrite : Attr = c % d;
   let log2Rewrite : Attr = log2(c);
   let exp2Rewrite : Attr = exp2(d);
+  let absRewrite : Attr = abs(attr<"-4 : si32">);
 }
 
 Pattern TestOperatorContext {
@@ -535,10 +545,14 @@ Pattern TestOperatorContext {
 // CHECK: -UserConstraintDecl {{.*}} Name<__builtin_addConstraint> ResultType<Attr>
 // CHECK: -UserConstraintDecl {{.*}} Name<__builtin_exp2Constraint> ResultType<Attr>
 // CHECK: Arguments
-// CHECK: -UserConstraintDecl {{.*}} Name<__builtin_addConstraint> ResultType<Attr> 
+// CHECK: -UserConstraintDecl {{.*}} Name<__builtin_addConstraint> ResultType<Attr>
+// CHECK: -UserConstraintDecl {{.*}} Name<__builtin_absConstraint> ResultType<Attr>
+// CHECK: Arguments
+// CHECK: -UserConstraintDecl {{.*}} Name<__builtin_addConstraint> ResultType<Attr>
 Pattern {
   let log2Constraint : Attr = log2(attr<"4 : i32"> + attr<"4 : i32">);
   let exp2Constraint : Attr = exp2(attr<"2 : i32"> + attr<"2 : i32">);
+  let absConstraint : Attr = abs(attr<"-4 : si32"> + attr<"-2 : si32">);
   erase _: Op;
 }
 
@@ -553,6 +567,7 @@ Pattern {
 // CHECK: UserConstraintDecl {{.*}} Name<__builtin_modConstraint> ResultType<Attr>
 // CHECK: UserConstraintDecl {{.*}} Name<__builtin_log2Constraint> ResultType<Attr>
 // CHECK: UserConstraintDecl {{.*}} Name<__builtin_exp2Constraint> ResultType<Attr>
+// CHECK: UserConstraintDecl {{.*}} Name<__builtin_absConstraint> ResultType<Attr>
 Pattern {
   attr<"4 : i32"> + attr<"5 : i32">;
   attr<"4 : i32"> - attr<"5 : i32">;
@@ -561,6 +576,7 @@ Pattern {
   attr<"4 : i32"> % attr<"5 : i32">;
   log2(attr<"4 : i32">);
   exp2(attr<"4 : i32">);
+  abs(attr<"-4 : si32">);
   erase _: Op;
 }
 

--- a/mlir/unittests/Dialect/PDL/BuiltinTest.cpp
+++ b/mlir/unittests/Dialect/PDL/BuiltinTest.cpp
@@ -752,6 +752,19 @@ TEST_F(BuiltinTest, abs) {
         7);
   }
 
+  // signless integer: edge case -128
+  // Overflow should not be checked
+  // otherwise the purpose of signless integer is meaningless
+  {
+    auto value = rewriter.getI8IntegerAttr(-128);
+    TestPDLResultList results(1);
+    EXPECT_TRUE(builtin::abs(rewriter, results, {value}).succeeded());
+    auto result = results.getResults()[0];
+    EXPECT_EQ(
+        cast<IntegerAttr>(result.cast<Attribute>()).getValue().getSExtValue(),
+        -128);
+  }
+
   // float
   {
     auto value = rewriter.getF32FloatAttr(-1.0);


### PR DESCRIPTION
PDLL native operator abs (use case in flexml: https://gitenterprise.xilinx.com/FaaSApps/vitis_flexml/blob/78229fda971cc942e06d78867c864f877b1437e9/data/Transform/pdll/shared/native_calls.pdll#L89) and some code refactor in `Builtins.cpp` and `Builtins.h`