### PR TITLE
[PDLL] change abs to math_abs

### DIFF
--- a/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
@@ -377,7 +377,7 @@ Token Lexer::lexIdentifier(const char *tokStart) {
                          .Case("_", Token::underscore)
                          .Case("log2", Token::log2)
                          .Case("exp2", Token::exp2)
-                         .Case("abs", Token::abs)
+                         .Case("math_abs", Token::abs)
                          .Default(Token::identifier);
   return Token(kind, str);
 }

--- a/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
+++ b/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
@@ -321,7 +321,7 @@ Pattern TestOperatorsNotInRewriteSection {
   let modConstraint : Attr = a % b;
   let log2Constraint : Attr = log2(a);
   let exp2Constraint : Attr = exp2(a);
-  let absConstraint : Attr = abs(a);
+  let absConstraint : Attr = math_abs(a);
   replace op<test.simple> with op<test.success>;
 }
 
@@ -351,7 +351,7 @@ Pattern TestOperatorsInRewriteSection {
     let modRewrite : Attr = a % b;
     let log2Rewrite : Attr = log2(a);
     let exp2Rewrite : Attr = exp2(a);
-    let absRewrite : Attr = abs(a);
+    let absRewrite : Attr = math_abs(a);
     erase root;
   };
 }

--- a/mlir/test/mlir-pdll/Parser/expr-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr-failure.pdll
@@ -585,7 +585,7 @@ Pattern {
   // CHECK: cannot evaluate abs operator in rewrite section. Assign to a variable with `let`
   let root = op<>(operand: Value, operands: ValueRange) -> (type: Type, types: TypeRange);
   rewrite root with {
-    abs(attr<"-4 : si32">);
+    math_abs(attr<"-4 : si32">);
     erase root;
   };
 }
@@ -624,7 +624,7 @@ Pattern {
   let root = op<>(operand: Value, operands: ValueRange) -> (type: Type, types: TypeRange);
   rewrite root with {
     let a : Attr = attr<"4 : i32"> + attr<"5 : i32">;
-    abs(attr<"4 : i32">);
+    math_abs(attr<"4 : i32">);
     erase root;
   };
 }

--- a/mlir/test/mlir-pdll/Parser/expr.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr.pdll
@@ -470,7 +470,7 @@ Pattern {
   let modConstraint : Attr = a % b;
   let log2Constraint : Attr = log2(a);
   let exp2Constraint : Attr = exp2(b);
-  let absConstraint : Attr = abs(attr<"-4 : si32">);
+  let absConstraint : Attr = math_abs(attr<"-4 : si32">);
   rewrite root with {
     let addRewrite : Attr = attr<"4 : i32"> + attr<"5 : i32">;
     let subRewrite : Attr = attr<"4 : i32"> - attr<"5 : i32">;
@@ -479,7 +479,7 @@ Pattern {
     let modRewrite : Attr = attr<"4 : i32"> % attr<"5 : i32">;
     let log2Rewrite : Attr = log2(attr<"4 : i32">);
     let exp2Rewrite : Attr = exp2(attr<"4 : i32">);
-    let absRewrite : Attr = abs(attr<"-4 : si32">);
+    let absRewrite : Attr = math_abs(attr<"-4 : si32">);
     erase root;
   };
 }
@@ -513,7 +513,7 @@ Constraint TestConstraint(attr: Attr, op: Op, type: Type, value: Value, typeRang
   let modConstraint : Attr = a % b;
   let log2Constraint : Attr = log2(a);
   let exp2Constraint : Attr = exp2(b);
-  let absConstraint : Attr = abs(attr<"-4 : si32">);
+  let absConstraint : Attr = math_abs(attr<"-4 : si32">);
 }
 
 Rewrite TestRewrite(attr: Attr, op: Op, type: Type, value: Value, typeRange: TypeRange, valueRange: ValueRange) {
@@ -526,7 +526,7 @@ Rewrite TestRewrite(attr: Attr, op: Op, type: Type, value: Value, typeRange: Typ
   let modRewrite : Attr = c % d;
   let log2Rewrite : Attr = log2(c);
   let exp2Rewrite : Attr = exp2(d);
-  let absRewrite : Attr = abs(attr<"-4 : si32">);
+  let absRewrite : Attr = math_abs(attr<"-4 : si32">);
 }
 
 Pattern TestOperatorContext {
@@ -552,7 +552,7 @@ Pattern TestOperatorContext {
 Pattern {
   let log2Constraint : Attr = log2(attr<"4 : i32"> + attr<"4 : i32">);
   let exp2Constraint : Attr = exp2(attr<"2 : i32"> + attr<"2 : i32">);
-  let absConstraint : Attr = abs(attr<"-4 : si32"> + attr<"-2 : si32">);
+  let absConstraint : Attr = math_abs(attr<"-4 : si32"> + attr<"-2 : si32">);
   erase _: Op;
 }
 
@@ -576,7 +576,7 @@ Pattern {
   attr<"4 : i32"> % attr<"5 : i32">;
   log2(attr<"4 : i32">);
   exp2(attr<"4 : i32">);
-  abs(attr<"-4 : si32">);
+  math_abs(attr<"-4 : si32">);
   erase _: Op;
 }
 


### PR DESCRIPTION
Context: there is name conflict between `abs` pdll native operator and  https://gitenterprise.xilinx.com/FaaSApps/vitis_flexml/blob/113a5853907a74d256da777e499008f2345669a8/data/Transform/pdll/data_format_agnostic_patterns/elementwise_unary.pdll#L46. 