### PR TITLE
[Tosa] support sin/cos constant fold

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/TosaFolders.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaFolders.cpp
@@ -1247,6 +1247,46 @@ struct TosaFoldConstantLog
   }
 };
 
+struct TosaFoldConstantSin
+    : public TosaFoldConstantUnaryElementwise<TosaFoldConstantSin, SinOp> {
+  using TosaFoldConstantUnaryElementwise<
+      TosaFoldConstantSin, SinOp>::TosaFoldConstantUnaryElementwise;
+
+  DenseElementsAttr computeFloat(DenseElementsAttr values,
+                                 PatternRewriter &rewriter, TosaOp op) const {
+    return applyElementWise<APFloat, APFloat, FloatType>(
+        values,
+        [](const APFloat &val, FloatType) {
+          auto res = APFloat(std::sin(val.convertToFloat()));
+          bool lostPrecision;
+          res.convert(val.getSemantics(), APFloat::rmNearestTiesToEven,
+                      &lostPrecision);
+          return res;
+        },
+        cast<FloatType>(values.getElementType()));
+  }
+};
+
+struct TosaFoldConstantCos
+    : public TosaFoldConstantUnaryElementwise<TosaFoldConstantCos, CosOp> {
+  using TosaFoldConstantUnaryElementwise<
+      TosaFoldConstantCos, CosOp>::TosaFoldConstantUnaryElementwise;
+
+  DenseElementsAttr computeFloat(DenseElementsAttr values,
+                                 PatternRewriter &rewriter, TosaOp op) const {
+    return applyElementWise<APFloat, APFloat, FloatType>(
+        values,
+        [](const APFloat &val, FloatType) {
+          auto res = APFloat(std::cos(val.convertToFloat()));
+          bool lostPrecision;
+          res.convert(val.getSemantics(), APFloat::rmNearestTiesToEven,
+                      &lostPrecision);
+          return res;
+        },
+        cast<FloatType>(values.getElementType()));
+  }
+};
+
 struct TosaFoldConstantBitwiseAnd
     : public TosaFoldConstantBinary<TosaFoldConstantBitwiseAnd, BitwiseAndOp> {
   using TosaFoldConstantBinary<TosaFoldConstantBitwiseAnd,
@@ -1772,6 +1812,8 @@ void mlir::tosa::populateTosaFoldConstantPatterns(
   patterns.add<TosaFoldConstantErf>(ctx, foldSplatOrSingleUseOnly);
   patterns.add<TosaFoldConstantExp>(ctx, foldSplatOrSingleUseOnly);
   patterns.add<TosaFoldConstantLog>(ctx, foldSplatOrSingleUseOnly);
+  patterns.add<TosaFoldConstantCos>(ctx, foldSplatOrSingleUseOnly);
+  patterns.add<TosaFoldConstantSin>(ctx, foldSplatOrSingleUseOnly);
   patterns.add<TosaFoldConstantBitwiseAnd>(ctx, foldSplatOrSingleUseOnly);
   patterns.add<TosaFoldConstantBitwiseOr>(ctx, foldSplatOrSingleUseOnly);
   patterns.add<TosaFoldConstantGreaterEqual>(ctx, foldSplatOrSingleUseOnly);

--- a/mlir/test/Dialect/Tosa/constant-cos.mlir
+++ b/mlir/test/Dialect/Tosa/constant-cos.mlir
@@ -1,0 +1,75 @@
+// RUN: mlir-opt --split-input-file --tosa-layerwise-constant-fold %s | FileCheck %s
+
+// CHECK-LABEL: @cos_fold_single_valued
+func.func @cos_fold_single_valued() -> tensor<f32> {
+    // CHECK: [[RES:]] ={{.*}}tosa.const{{.*}}1.000000e+00{{.*}} tensor<f32>
+    // CHECK-NOT: tosa.cos
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<0.0> : tensor<f32>} : () -> tensor<f32>
+    %1 = "tosa.cos"(%0) : (tensor<f32>) -> tensor<f32>
+    return %1 : tensor<f32>
+}
+
+// CHECK-LABEL: @cos_fold_splat
+func.func @cos_fold_splat() -> tensor<2x3xf32> {
+    // CHECK: [[RES:]] ={{.*}}tosa.const{{.*}}1.000000e+00{{.*}} tensor<2x3xf32>
+    // CHECK-NOT: tosa.cos
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<0.0> : tensor<2x3xf32>} : () -> tensor<2x3xf32>
+    %1 = "tosa.cos"(%0) : (tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %1 : tensor<2x3xf32>
+}
+
+// CHECK-LABEL: @cos_fold_bf16
+func.func @cos_fold_bf16() -> tensor<2x3xbf16> {
+    // CHECK: [[RES:]] ={{.*}}tosa.const{{.*}}8.125000e-01
+    // CHECK-NOT: tosa.cos
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<0.625> : tensor<2x3xbf16>} : () -> tensor<2x3xbf16>
+    %1 = "tosa.cos"(%0) : (tensor<2x3xbf16>) -> tensor<2x3xbf16>
+    return %1 : tensor<2x3xbf16>
+}
+
+// CHECK-LABEL: @cos_neg_zero
+func.func @cos_neg_zero() -> tensor<f32> {
+    // CHECK: [[RES:]] = {{.*}}tosa.const{{.*}}1.000000e+00
+    // CHECK-NOT: tosa.cos
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<-0.0> : tensor<f32>} : () -> tensor<f32>
+    %1 = "tosa.cos"(%0) : (tensor<f32>) -> tensor<f32>
+    return %1 : tensor<f32>
+}
+
+// CHECK-LABE: @cos_nan
+func.func @cos_nan() -> tensor<f32> {
+    // CHECK: [[RES:]] = {{.*}}tosa.const{{.*}}0x7FC00000
+    // CHECK-NOT: tosa.cos
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<0x7FC00000> : tensor<f32>} : () -> tensor<f32>
+    %1 = "tosa.cos"(%0) : (tensor<f32>) -> tensor<f32>
+    return %1 : tensor<f32>
+}
+
+// CHECK-LABEL: @cos_no_fold
+func.func @cos_no_fold(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    // CHECK: tosa.cos
+    // CHECK-NEXT: return
+    %0 = "tosa.cos"(%arg0) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+    return %0 : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: @cos_fold
+func.func @cos_fold() -> tensor<2x3xf32> {
+    // CHECK: [[RES:]] ={{.*}}tosa.const
+    // CHECK-SAME: 0.9920{{[0-9]+}}, 0.9999{{[0-9]+}}, 0.9850{{[0-9]+}}
+    // CHECK-SAME: [0.6677{{[0-9]+}}, 0.8206{{[0-9]+}}, 0.8893{{[0-9]+}}
+    // CHECK-NOT: tosa.cos
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() { value = dense<[
+                          [ 0.1259, 0.0086, 0.1734],
+                          [-0.8396, 0.6082, 0.4749]]>
+                          : tensor<2x3xf32>
+                        } : () -> tensor<2x3xf32>
+    %1 = "tosa.cos"(%0) : (tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %1 : tensor<2x3xf32>
+}

--- a/mlir/test/Dialect/Tosa/constant-sin.mlir
+++ b/mlir/test/Dialect/Tosa/constant-sin.mlir
@@ -1,0 +1,75 @@
+// RUN: mlir-opt --split-input-file --tosa-layerwise-constant-fold %s | FileCheck %s
+
+// CHECK-LABEL: @sin_fold_single_valued
+func.func @sin_fold_single_valued() -> tensor<f32> {
+    // CHECK: [[RES:]] ={{.*}}tosa.const{{.*}}0.000000e+00{{.*}} tensor<f32>
+    // CHECK-NOT: tosa.sin
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<0.0> : tensor<f32>} : () -> tensor<f32>
+    %1 = "tosa.sin"(%0) : (tensor<f32>) -> tensor<f32>
+    return %1 : tensor<f32>
+}
+
+// CHECK-LABEL: @sin_fold_splat
+func.func @sin_fold_splat() -> tensor<2x3xf32> {
+    // CHECK: [[RES:]] ={{.*}}tosa.const{{.*}}0.000000e+00{{.*}} tensor<2x3xf32>
+    // CHECK-NOT: tosa.sin
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<0.0> : tensor<2x3xf32>} : () -> tensor<2x3xf32>
+    %1 = "tosa.sin"(%0) : (tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %1 : tensor<2x3xf32>
+}
+
+// CHECK-LABEL: @sin_fold_bf16
+func.func @sin_fold_bf16() -> tensor<2x3xbf16> {
+    // CHECK: [[RES:]] ={{.*}}tosa.const{{.*}}6.250000e-02
+    // CHECK-NOT: tosa.sin
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<0.0625> : tensor<2x3xbf16>} : () -> tensor<2x3xbf16>
+    %1 = "tosa.sin"(%0) : (tensor<2x3xbf16>) -> tensor<2x3xbf16>
+    return %1 : tensor<2x3xbf16>
+}
+
+// CHECK-LABEL: @sin_neg_zero
+func.func @sin_neg_zero() -> tensor<f32> {
+    // CHECK: [[RES:]] = {{.*}}tosa.const{{.*}}-0.000000e+00
+    // CHECK-NOT: tosa.sin
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<-0.0> : tensor<f32>} : () -> tensor<f32>
+    %1 = "tosa.sin"(%0) : (tensor<f32>) -> tensor<f32>
+    return %1 : tensor<f32>
+}
+
+// CHECK-LABE: @sin_nan
+func.func @sin_nan() -> tensor<f32> {
+    // CHECK: [[RES:]] = {{.*}}tosa.const{{.*}}0x7FC00000
+    // CHECK-NOT: tosa.sin
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() {value = dense<0x7FC00000> : tensor<f32>} : () -> tensor<f32>
+    %1 = "tosa.sin"(%0) : (tensor<f32>) -> tensor<f32>
+    return %1 : tensor<f32>
+}
+
+// CHECK-LABEL: @sin_no_fold
+func.func @sin_no_fold(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    // CHECK: tosa.sin
+    // CHECK-NEXT: return
+    %0 = "tosa.sin"(%arg0) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+    return %0 : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: @sin_fold
+func.func @sin_fold() -> tensor<2x3xf32> {
+    // CHECK: [[RES:]] ={{.*}}tosa.const
+    // CHECK-SAME: 0.1255{{[0-9]+}}, 0.0085{{[0-9]+}}, 0.1725{{[0-9]+}}
+    // CHECK-SAME: [-0.7443{{[0-9]+}}, 0.5713{{[0-9]+}}, 0.6996{{[0-9]+}}
+    // CHECK-NOT: tosa.sin
+    // CHECK: return [[RES]]
+    %0 = "tosa.const"() { value = dense<[
+                          [ 0.1259, 0.0086, 0.1734],
+                          [-0.8396, 0.6082, 0.7749]]>
+                          : tensor<2x3xf32>
+                        } : () -> tensor<2x3xf32>
+    %1 = "tosa.sin"(%0) : (tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %1 : tensor<2x3xf32>
+}


### PR DESCRIPTION
https://github.com/Xilinx/llvm-project/pull/178 closed. Same, reverting the format completely is easier in this way.
`tosa.sin` and `tosa.cos` support only `bf16`, `f16`, and `f32`.