### PR TITLE
feat: constant fold tosa.tile.

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
@@ -30,10 +30,9 @@ void populateTosaDecomposeTransposeConv(MLIRContext *ctx,
                                         RewritePatternSet &patterns);
 void populateTosaDecomposeDepthwise(MLIRContext *ctx,
                                     RewritePatternSet &patterns);
-void populateTosaFoldConstantPatterns(MLIRContext *ctx,
-                                      RewritePatternSet &patterns,
-                                      bool foldSplatOrSingleUseOnly,
-                                      bool enableIntCastFolding);
+void populateTosaFoldConstantPatterns(
+    MLIRContext *ctx, RewritePatternSet &patterns,
+    const TosaLayerwiseConstantFoldPassOptions &options);
 void populateTosaConstantReduction(MLIRContext *ctx,
                                    RewritePatternSet &patterns,
                                    bool aggressiveReduceConstant);

--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -32,6 +32,9 @@ def TosaLayerwiseConstantFoldPass : Pass<"tosa-layerwise-constant-fold", "func::
             /*default=*/"false",
             "Always perform the reduce constant optimization"
             "May add more tosa.const but would reduce runtime calculations">,
+    Option<"enableTileFolding", "enable-tile-folding", "bool",
+            /*default=*/"false",
+            "Enables folding of tosa.tile operation. May generate bigger constant values.">,
   ];
 }
 

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaLayerwiseConstantFoldPass.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaLayerwiseConstantFoldPass.cpp
@@ -52,8 +52,13 @@ struct TosaLayerwiseConstantFoldPass
     RewritePatternSet patterns(ctx);
     auto func = getOperation();
 
-    mlir::tosa::populateTosaFoldConstantPatterns(
-        ctx, patterns, foldSplatOrSingleUseOnly, enableIntCastFolding);
+    TosaLayerwiseConstantFoldPassOptions options;
+    options.enableIntCastFolding = enableIntCastFolding;
+    options.foldSplatOrSingleUseOnly = foldSplatOrSingleUseOnly;
+    options.aggressiveReduceConstant = aggressiveReduceConstant;
+    options.enableTileFolding = enableTileFolding;
+
+    mlir::tosa::populateTosaFoldConstantPatterns(ctx, patterns, options);
     mlir::tosa::populateTosaConstantReduction(ctx, patterns,
                                               aggressiveReduceConstant);
     populateTosaOpsCanonicalizationPatterns(ctx, patterns);

--- a/mlir/test/Dialect/Tosa/constant-tile.mlir
+++ b/mlir/test/Dialect/Tosa/constant-tile.mlir
@@ -1,0 +1,109 @@
+// RUN: mlir-opt --split-input-file --tosa-layerwise-constant-fold=enable-tile-folding=true %s | FileCheck %s
+// RUN: mlir-opt --split-input-file --tosa-layerwise-constant-fold %s | FileCheck --check-prefix=NO-FOLDING-CHECK %s
+
+// CHECK-LABEL: @tile_int_one_dim
+func.func @tile_int_one_dim() -> (tensor<6xi32>) {
+  // CHECK: "tosa.const"() <{value = dense
+  // CHECK-SAME: {{\[}}1, 2, 3, 1, 2, 3]
+  %0 = "tosa.const"() {value = dense<[1, 2, 3]> : tensor<3xi32>} : () -> tensor<3xi32>
+  %1 = tosa.tile %0 {multiples = array<i64: 2>} : (tensor<3xi32>) -> tensor<6xi32>
+  return %1 : tensor<6xi32>
+  // NO-FOLDING-CHECK: tosa.tile
+}
+
+// CHECK-LABEL: @tile_bool
+func.func @tile_bool() -> (tensor<1x3x2x3xi1>) {
+  // CHECK: "tosa.const"() <{value = dense
+  // CHECK-SAME: {{\[\[}}{{\[\[}}true, true, true],
+  // CHECK-SAME: [true, true, true]],
+  // CHECK-SAME: [false, false, false],
+  // CHECK-SAME: [false, false, false]],
+  // CHECK-SAME: [true, true, true],
+  // CHECK-SAME: [true, true, true]]]]
+  %0 = "tosa.const"() {value = dense<[[[[true]], [[false]], [[true]]]]> : tensor<1x3x1x1xi1>} : () -> tensor<1x3x1x1xi1>
+  %1 = tosa.tile %0 {multiples = array<i64: 1, 1, 2, 3>} : (tensor<1x3x1x1xi1>) -> tensor<1x3x2x3xi1>
+  return %1 : tensor<1x3x2x3xi1>
+  // NO-FOLDING-CHECK: tosa.tile
+}
+
+// CHECK-LABEL: @tile_bf16
+func.func @tile_bf16() -> (tensor<1x3x2x2xbf16>) {
+  // CHECK: "tosa.const"() <{value = dense
+  // CHECK-SAME: {{\[\[}}{{\[\[}}2.500000e-01, 1.250000e-01],
+  // CHECK-SAME:  [2.500000e-01, 1.250000e-01]],
+  // CHECK-SAME:  [5.000000e-01, 1.000000e+00],
+  // CHECK-SAME:  [5.000000e-01, 1.000000e+00]],
+  // CHECK-SAME:  [2.000000e+00, 4.000000e+00],
+  // CHECK-SAME:  [2.000000e+00, 4.000000e+00]]]]
+  %0 = "tosa.const"() {value = dense<[[[[0.25, 0.125]], [[0.5, 1.0]], [[2.0, 4.0]]]]> : tensor<1x3x1x2xbf16>} : () -> tensor<1x3x1x2xbf16>
+  %1 = tosa.tile %0 {multiples = array<i64: 1, 1, 2, 1>} : (tensor<1x3x1x2xbf16>) -> tensor<1x3x2x2xbf16>
+  return %1 : tensor<1x3x2x2xbf16>
+  // NO-FOLDING-CHECK: tosa.tile
+}
+
+// CHECK-LABEL: @tile_f32
+func.func @tile_f32() -> (tensor<4x4xf32>) {
+  // CHECK: "tosa.const"() <{value = dense
+  // CHECK-SAME: {{\[\[}}2.500000e-01, 1.250000e+00, 2.500000e-01, 1.250000e+00],
+  // CHECK-SAME: [2.250000e+00, 3.250000e+00, 2.250000e+00, 3.250000e+00],
+  // CHECK-SAME: [2.500000e-01, 1.250000e+00, 2.500000e-01, 1.250000e+00],
+  // CHECK-SAME: [2.250000e+00, 3.250000e+00, 2.250000e+00, 3.250000e+00]]
+  %0 = "tosa.const"() {value = dense<[[0.25, 1.25],[2.25, 3.25]]> : tensor<2x2xf32>} : () -> tensor<2x2xf32>
+  %1 = tosa.tile %0 {multiples = array<i64: 2, 2>} : (tensor<2x2xf32>) -> tensor<4x4xf32>
+  return %1 : tensor<4x4xf32>
+  // NO-FOLDING-CHECK: tosa.tile
+}
+
+// CHECK-LABEL: @tile_int_many_dimensions
+func.func @tile_int_many_dimensions() -> (tensor<4x6x4xi32>) {
+  // CHECK: "tosa.const"() <{value = dense
+  // CHECK-SAME: {{\[\[\[}}1, 2, 1, 2],
+  // CHECK-SAME:  [3, 4, 3, 4],
+  // CHECK-SAME:  [5, 6, 5, 6],
+  // CHECK-SAME:  [1, 2, 1, 2],
+  // CHECK-SAME:  [3, 4, 3, 4],
+  // CHECK-SAME:  [5, 6, 5, 6]],
+  // CHECK-SAME: {{\[\[}}7, 8, 7, 8],
+  // CHECK-SAME:  [9, 10, 9, 10],
+  // CHECK-SAME:  [11, 12, 11, 12],
+  // CHECK-SAME:  [7, 8, 7, 8],
+  // CHECK-SAME:  [9, 10, 9, 10],
+  // CHECK-SAME:  [11, 12, 11, 12]],
+  // CHECK-SAME: {{\[\[}}1, 2, 1, 2],
+  // CHECK-SAME:  [3, 4, 3, 4],
+  // CHECK-SAME:  [5, 6, 5, 6],
+  // CHECK-SAME:  [1, 2, 1, 2],
+  // CHECK-SAME:  [3, 4, 3, 4],
+  // CHECK-SAME:  [5, 6, 5, 6]],
+  // CHECK-SAME: {{\[\[}}7, 8, 7, 8],
+  // CHECK-SAME:  [9, 10, 9, 10],
+  // CHECK-SAME:  [11, 12, 11, 12],
+  // CHECK-SAME:  [7, 8, 7, 8],
+  // CHECK-SAME:  [9, 10, 9, 10],
+  // CHECK-SAME:  [11, 12, 11, 12]]]
+  %0 = "tosa.const"() {value = dense<[[[1, 2],[3, 4],[5, 6]], [[7, 8],[9, 10],[11, 12]]]> : tensor<2x3x2xi32>} : () -> tensor<2x3x2xi32>
+  %1 = tosa.tile %0 {multiples = array<i64: 2, 2, 2>} : (tensor<2x3x2xi32>) -> tensor<4x6x4xi32>
+  // NO-FOLDING-CHECK: tosa.tile
+  return %1 : tensor<4x6x4xi32>
+}
+
+// CHECK-LABEL: @tile_f16_many_dimensions
+func.func @tile_f16_many_dimensions() -> (tensor<6x2x2xf16>) {
+  // CHECK: "tosa.const"() <{value = dense
+  // CHECK-SAME: {{\[\[\[}}1.000000e+00, 1.000000e+00],
+  // CHECK-SAME:  [1.000000e+00, 1.000000e+00]],
+  // CHECK-SAME: {{\[\[}}2.000000e+00, 2.000000e+00],
+  // CHECK-SAME:  [2.000000e+00, 2.000000e+00]],
+  // CHECK-SAME: {{\[\[}}3.000000e+00, 3.000000e+00],
+  // CHECK-SAME:  [3.000000e+00, 3.000000e+00]],
+  // CHECK-SAME: {{\[\[}}1.000000e+00, 1.000000e+00],
+  // CHECK-SAME:  [1.000000e+00, 1.000000e+00]],
+  // CHECK-SAME: {{\[\[}}2.000000e+00, 2.000000e+00],
+  // CHECK-SAME:  [2.000000e+00, 2.000000e+00]],
+  // CHECK-SAME: {{\[\[}}3.000000e+00, 3.000000e+00],
+  // CHECK-SAME:  [3.000000e+00, 3.000000e+00]]]
+  %0 = "tosa.const"() {value = dense<[[[1.0]], [[2.0]], [[3.0]]]> : tensor<3x1x1xf16>} : () -> tensor<3x1x1xf16>
+  %1 = tosa.tile %0 {multiples = array<i64: 3, 2, 1>} : (tensor<3x1x1xf16>) -> tensor<6x2x2xf16>
+  // NO-FOLDING-CHECK: tosa.tile
+  return %1 : tensor<6x2x2xf16>
+}


### PR DESCRIPTION
Constant fold `tosa.tile` when `enable-tile-folding=true` is passed as option.

Tests results were generated using `pytorch`:
```
import torch

torch.set_printoptions(sci_mode=True, precision=6)

x = torch.tensor([1, 2, 3])
print(x)
print(x.tile((2,)))

x = torch.tensor([[[[True]],[[False]],[[True]]]])
print(x)
print(x.tile((1,1,2,3)))

x = torch.tensor([[[[0.25, 0.125]],[[0.5, 1.0]],[[2.0, 4.0]]]], dtype=torch.bfloat16)
print(x)
print(x.tile((1,1,2,1)))


x = torch.tensor([[0.25, 1.25], [2.25, 3.25]])
print(x)
print(torch.tile(x, (2, 2)))

x = torch.tensor([[[1, 2],[3, 4],[5, 6]], [[7, 8],[9, 10],[11, 12]]])
print(x)
print(torch.tile(x, (2, 2, 2)))


x = torch.tensor([[[1.0]], [[2.0]], [[3.0]]], dtype=torch.float16)
print(x)
print(torch.tile(x, (2, 2, 2)))
```