### PR TITLE
Fix discrepancy in EmitC parser/printer

### DIFF
--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -401,7 +401,7 @@ ParseResult ForOp::parse(OpAsmParser &parser, OperationState &result) {
 
   // Parse optional type, else assume Index.
   if (parser.parseOptionalColon())
-    type = builder.getIndexType();
+    type = emitc::SizeTType::get(builder.getContext());
   else if (parser.parseType(type))
     return failure();
 
@@ -431,8 +431,7 @@ void ForOp::print(OpAsmPrinter &p) {
     << getUpperBound() << " step " << getStep();
 
   p << ' ';
-  if (Type t = getInductionVar().getType();
-      !(t.isIndex() || emitc::isAnySizeTType(t)))
+  if (Type t = getInductionVar().getType(); !(isa<emitc::SizeTType>(t)))
     p << " : " << t << ' ';
   p.printRegion(getRegion(),
                 /*printEntryBlockArgs=*/false,

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -399,7 +399,7 @@ ParseResult ForOp::parse(OpAsmParser &parser, OperationState &result) {
   SmallVector<OpAsmParser::UnresolvedOperand, 4> operands;
   regionArgs.push_back(inductionVariable);
 
-  // Parse optional type, else assume Index.
+  // Parse optional type, else assume size_t.
   if (parser.parseOptionalColon())
     type = emitc::SizeTType::get(builder.getContext());
   else if (parser.parseType(type))

--- a/mlir/test/Dialect/EmitC/ops.mlir
+++ b/mlir/test/Dialect/EmitC/ops.mlir
@@ -192,16 +192,16 @@ func.func @test_expression(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: f32, %arg4
   return %r : i32
 }
 
-func.func @test_for(%arg0 : index, %arg1 : index, %arg2 : index) {
+func.func @test_for(%arg0 : !emitc.size_t, %arg1 : !emitc.size_t, %arg2 : !emitc.size_t) {
   emitc.for %i0 = %arg0 to %arg1 step %arg2 {
-    %0 = emitc.call_opaque "func_const"(%i0) : (index) -> i32
+    %0 = emitc.call_opaque "func_const"(%i0) : (!emitc.size_t) -> i32
   }
   return
 }
 
-func.func @test_for_explicit_yield(%arg0 : index, %arg1 : index, %arg2 : index) {
+func.func @test_for_explicit_yield(%arg0 : !emitc.size_t, %arg1 : !emitc.size_t, %arg2 : !emitc.size_t) {
   emitc.for %i0 = %arg0 to %arg1 step %arg2 {
-    %0 = emitc.call_opaque "func_const"(%i0) : (index) -> i32
+    %0 = emitc.call_opaque "func_const"(%i0) : (!emitc.size_t) -> i32
     emitc.yield
   }
   return

--- a/mlir/test/Target/Cpp/for.mlir
+++ b/mlir/test/Target/Cpp/for.mlir
@@ -1,18 +1,18 @@
 // RUN: mlir-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
 // RUN: mlir-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
 
-func.func @test_for(%arg0 : index, %arg1 : index, %arg2 : index) {
-  %lb = emitc.expression : index {
-    %a = emitc.add %arg0, %arg1 : (index, index) -> index
-    emitc.yield %a : index
+func.func @test_for(%arg0 : !emitc.size_t, %arg1 : !emitc.size_t, %arg2 : !emitc.size_t) {
+  %lb = emitc.expression : !emitc.size_t {
+    %a = emitc.add %arg0, %arg1 : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+    emitc.yield %a : !emitc.size_t
   }
-  %ub = emitc.expression : index {
-    %a = emitc.mul %arg1, %arg2 : (index, index) -> index
-    emitc.yield %a : index
+  %ub = emitc.expression : !emitc.size_t {
+    %a = emitc.mul %arg1, %arg2 : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+    emitc.yield %a : !emitc.size_t
   }
-  %step = emitc.expression : index {
-    %a = emitc.div %arg0, %arg2 : (index, index) -> index
-    emitc.yield %a : index
+  %step = emitc.expression : !emitc.size_t {
+    %a = emitc.div %arg0, %arg2 : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
+    emitc.yield %a : !emitc.size_t
   }
   emitc.for %i0 = %lb to %ub step %step {
     %0 = emitc.call_opaque "f"() : () -> i32
@@ -33,9 +33,9 @@ func.func @test_for(%arg0 : index, %arg1 : index, %arg2 : index) {
 // CPP-DECLTOP-NEXT: return;
 
 func.func @test_for_yield() {
-  %start = "emitc.constant"() <{value = 0 : index}> : () -> index
-  %stop = "emitc.constant"() <{value = 10 : index}> : () -> index
-  %step = "emitc.constant"() <{value = 1 : index}> : () -> index
+  %start = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
+  %stop = "emitc.constant"() <{value = 10 : index}> : () -> !emitc.size_t
+  %step = "emitc.constant"() <{value = 1 : index}> : () -> !emitc.size_t
 
   %s0 = "emitc.constant"() <{value = 0 : i32}> : () -> i32
   %p0 = "emitc.constant"() <{value = 1.0 : f32}> : () -> f32
@@ -47,8 +47,8 @@ func.func @test_for_yield() {
   emitc.assign %s0 : i32 to %2 : i32
   emitc.assign %p0 : f32 to %3 : f32
   emitc.for %iter = %start to %stop step %step {
-    %sn = emitc.call_opaque "add"(%2, %iter) : (i32, index) -> i32
-    %pn = emitc.call_opaque "mul"(%3, %iter) : (f32, index) -> f32
+    %sn = emitc.call_opaque "add"(%2, %iter) : (i32, !emitc.size_t) -> i32
+    %pn = emitc.call_opaque "mul"(%3, %iter) : (f32, !emitc.size_t) -> f32
     emitc.assign %sn : i32 to %2 : i32
     emitc.assign %pn : f32 to %3 : f32
     emitc.yield
@@ -114,9 +114,9 @@ func.func @test_for_yield() {
 // CPP-DECLTOP-NEXT: return;
 
 func.func @test_for_yield_2() {
-  %start = emitc.literal "0" : index
-  %stop = emitc.literal "10" : index
-  %step = emitc.literal "1" : index
+  %start = emitc.literal "0" : !emitc.size_t
+  %stop = emitc.literal "10" : !emitc.size_t
+  %step = emitc.literal "1" : !emitc.size_t
 
   %s0 = emitc.literal "0" : i32
   %p0 = emitc.literal "M_PI" : f32
@@ -128,8 +128,8 @@ func.func @test_for_yield_2() {
   emitc.assign %s0 : i32 to %2 : i32
   emitc.assign %p0 : f32 to %3 : f32
   emitc.for %iter = %start to %stop step %step {
-    %sn = emitc.call_opaque "add"(%2, %iter) : (i32, index) -> i32
-    %pn = emitc.call_opaque "mul"(%3, %iter) : (f32, index) -> f32
+    %sn = emitc.call_opaque "add"(%2, %iter) : (i32, !emitc.size_t) -> i32
+    %pn = emitc.call_opaque "mul"(%3, %iter) : (f32, !emitc.size_t) -> f32
     emitc.assign %sn : i32 to %2 : i32
     emitc.assign %pn : f32 to %3 : f32
     emitc.yield


### PR DESCRIPTION
`emitc.size_t` is the default type in emitc::ForLoop induction variables now, so the type is not printed in the MLIR "assembly". However, index type is still assumed at parse time barring further type information in the IR. This commit reconciles the print and parse behavior to assume `emitc.size_t` as the default type.