### PR TITLE
Add missing cmpf conversion

### DIFF
--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -125,6 +125,10 @@ public:
       unordered = false;
       predicate = emitc::CmpPredicate::lt;
       break;
+    case arith::CmpFPredicate::OLE:
+      unordered = false;
+      predicate = emitc::CmpPredicate::le;
+      break;
     case arith::CmpFPredicate::ONE:
       unordered = false;
       predicate = emitc::CmpPredicate::ne;
@@ -179,9 +183,6 @@ public:
       rewriter.replaceOp(op, constant);
       return success();
     }
-    default:
-      return rewriter.notifyMatchFailure(op.getLoc(),
-                                         "cannot match predicate ");
     }
 
     // Compare the values naively

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -337,6 +337,21 @@ func.func @arith_cmpf_olt(%arg0: f32, %arg1: f32) -> i1 {
 
 // -----
 
+func.func @arith_cmpf_ole(%arg0: f32, %arg1: f32) -> i1 {
+  // CHECK-LABEL: arith_cmpf_ole
+  // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)
+  // CHECK-DAG: [[LT:[^ ]*]] = emitc.cmp le, [[Arg0]], [[Arg1]] : (f32, f32) -> i1
+  // CHECK-DAG: [[NaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
+  // CHECK-DAG: [[NaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
+  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NaNArg0]], [[NaNArg1]] : i1, i1
+  // CHECK-DAG: [[OLE:[^ ]*]] = emitc.logical_and [[Ordered]], [[LT]] : i1, i1
+  %ole = arith.cmpf ole, %arg0, %arg1 : f32
+  // CHECK: return [[OLE]]
+  return %ole: i1
+}
+
+// -----
+
 func.func @arith_cmpf_one(%arg0: f32, %arg1: f32) -> i1 {
   // CHECK-LABEL: arith_cmpf_one
   // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)


### PR DESCRIPTION
I was preparing the cmpf upstream PR an noticed we were missing `ole`. Since the switch now covers all cases, there was a warning that the default cannot be triggered, so I am pretty confident it is now complete 😄