### PR TITLE
[mlir][emitc] Implement arith.negf to EmitC

### DIFF
--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-unsupported.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-unsupported.mlir
@@ -81,6 +81,22 @@ func.func @arith_cast_fptoui_i1(%arg0: f32) -> i1 {
 
 // -----
 
+func.func @arith_negf_tensor(%arg0: tensor<5xf32>) -> tensor<5xf32> {
+  // expected-error @+1 {{failed to legalize operation 'arith.negf'}}
+  %n = arith.negf %arg0 : tensor<5xf32>
+  return %n: tensor<5xf32>
+}
+
+// -----
+
+func.func @arith_negf_vector(%arg0: vector<5xf32>) -> vector<5xf32> {
+  // expected-error @+1 {{failed to legalize operation 'arith.negf'}}
+  %n = arith.negf %arg0 : vector<5xf32>
+  return %n: vector<5xf32>
+}
+
+// -----
+
 func.func @arith_shli_i1(%arg0: i1, %arg1: i1) {
   // expected-error @+1 {{failed to legalize operation 'arith.shli'}}
   %shli = arith.shli %arg0, %arg1 : i1

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -560,6 +560,16 @@ func.func @arith_cmpi_index(%arg0: i32, %arg1: i32) -> i1 {
   return %slt: i1
 }
 
+// -----
+
+func.func @arith_negf(%arg0: f32) -> f32 {
+  // CHECK-LABEL: arith_negf
+  // CHECK-SAME: %[[Arg0:[^ ]*]]: f32
+  // CHECK: %[[N:[^ ]*]] = emitc.unary_minus %[[Arg0]] : (f32) -> f32
+  %n = arith.negf %arg0 : f32
+  // CHECK: return %[[N]]
+  return %n: f32
+}
 
 // -----
 


### PR DESCRIPTION
Convert `arith.negf` to `emitc.unary_minus`. Did not see any special cases here, so use a straight forward translation.