### PR TITLE
TosaToArith: Use type converter for tosa.const

### DIFF
--- a/mlir/include/mlir/Conversion/TosaToArith/TosaToArith.h
+++ b/mlir/include/mlir/Conversion/TosaToArith/TosaToArith.h
@@ -16,6 +16,7 @@
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
+class TypeConverter;
 
 #define GEN_PASS_DECL_TOSATOARITH
 #include "mlir/Conversion/Passes.h.inc"
@@ -25,7 +26,8 @@ namespace tosa {
 std::unique_ptr<Pass> createTosaToArith(bool includeApplyRescale = false,
                                         bool use32BitApplyRescale = false);
 
-void populateTosaToArithConversionPatterns(RewritePatternSet *patterns);
+void populateTosaToArithConversionPatterns(TypeConverter &converter,
+                                           RewritePatternSet *patterns);
 
 void populateTosaRescaleToArithConversionPatterns(RewritePatternSet *patterns,
                                                   bool include32Bit = false);

--- a/mlir/lib/Conversion/TosaToArith/TosaToArith.cpp
+++ b/mlir/lib/Conversion/TosaToArith/TosaToArith.cpp
@@ -15,8 +15,8 @@
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include <mlir/Transforms/DialectConversion.h>
 
 using namespace mlir;
 using namespace tosa;

--- a/mlir/lib/Conversion/TosaToArith/TosaToArithPass.cpp
+++ b/mlir/lib/Conversion/TosaToArith/TosaToArithPass.cpp
@@ -19,7 +19,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include <mlir/Conversion/TosaToLinalg/TosaToLinalg.h>
+#include "mlir/Conversion/TosaToLinalg/TosaToLinalg.h"
 
 namespace mlir {
 #define GEN_PASS_DEF_TOSATOARITH

--- a/mlir/lib/Conversion/TosaToArith/TosaToArithPass.cpp
+++ b/mlir/lib/Conversion/TosaToArith/TosaToArithPass.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include <mlir/Conversion/TosaToLinalg/TosaToLinalg.h>
 
 namespace mlir {
 #define GEN_PASS_DEF_TOSATOARITH
@@ -34,12 +35,15 @@ public:
   TosaToArith(TosaToArithOptions &options) : TosaToArithBase(options) {}
 
   void runOnOperation() override {
+    TypeConverter converter;
+    mlir::tosa::populateTosaToLinalgTypeConversion(converter);
+
     RewritePatternSet patterns(&getContext());
     ConversionTarget target(getContext());
     target.addIllegalOp<tosa::ConstOp>();
     target.addLegalDialect<arith::ArithDialect>();
 
-    mlir::tosa::populateTosaToArithConversionPatterns(&patterns);
+    mlir::tosa::populateTosaToArithConversionPatterns(converter, &patterns);
 
     if (this->includeApplyRescale) {
       mlir::tosa::populateTosaRescaleToArithConversionPatterns(&patterns,

--- a/mlir/test/Conversion/TosaToArith/tosa-to-arith.mlir
+++ b/mlir/test/Conversion/TosaToArith/tosa-to-arith.mlir
@@ -2,12 +2,16 @@
 // RUN: mlir-opt --split-input-file --tosa-to-arith="include-apply-rescale=false" %s -verify-diagnostics -o -| FileCheck --check-prefix="SCALE" %s
 
 // CHECK-LABEL: func @const_test
-func.func @const_test() -> (tensor<i32>) {
-  // CHECK: [[C3:%.+]] = arith.constant dense<3> : tensor<i32>
-  %result = "tosa.const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
+func.func @const_test() -> (tensor<i32>, tensor<ui32>) {
+  // CHECK: %[[CI32:.+]] = arith.constant dense<3> : tensor<i32>
+  %i32 = "tosa.const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
 
-  // CHECK: return [[C3]]
-  return %result : tensor<i32>
+  // CHECK: %[[CUI32:.+]] = arith.constant dense<3> : tensor<i32>
+  // CHECK: %[[CAST:.*]] = builtin.unrealized_conversion_cast %[[CUI32]] : tensor<i32> to tensor<ui32>
+  %ui32 = "tosa.const"() {value = dense<3> : tensor<ui32>} : () -> tensor<ui32>
+
+  // CHECK: return %[[CI32]], %[[CAST]]
+  return %i32, %ui32 : tensor<i32>,  tensor<ui32>
 }
 
 // -----


### PR DESCRIPTION
To ensure that ui8 consts become i8 in arith