### PR TITLE
[FXML-4770] TosaToLinalg: fix tosa.cast INT_MAX overflow constant

### DIFF
--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
@@ -563,7 +563,7 @@ static Value createLinalgBodyCalculationForElementwiseOp(
           loc, rewriter.getFloatAttr(
                    getElementTypeOrSelf(srcTy),
                    APInt::getSignedMaxValue(dstTy.getIntOrFloatBitWidth())
-                           .getSExtValue() +
+                           .getZExtValue() +
                        1));
 
       auto intMax = rewriter.create<arith::ConstantOp>(

--- a/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg.mlir
+++ b/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg.mlir
@@ -554,21 +554,32 @@ func.func @test_simple_f32(%arg0: tensor<1xf32>) -> () {
   %u20 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xui32>
 
   // CHECK: linalg.generic
+  // CHECK: [[ROUND:%.+]] = math.roundeven {{%.+}} : f32
+  // CHECK: [[CSTMIN:%.+]] = arith.constant -9.22337203E+18 : f32
+  // CHECK: [[CSTMAXP1:%.+]] = arith.constant 9.22337203E+18 : f32
+  // CHECK: [[CSTMAX:%.+]] = arith.constant 9223372036854775807 : i64
+  // CHECK: [[MAX:%.+]] = arith.maximumf [[ROUND]], [[CSTMIN]] : f32
+  // CHECK: [[CONV:%.+]] = arith.fptosi [[MAX]] : f32 to i64
+  // CHECK: [[CMP:%.+]] = arith.cmpf uge, [[ROUND]], [[CSTMAXP1]] : f32
+  // CHECK: arith.select [[CMP]], [[CSTMAX]], [[CONV]] : i64
+  %21 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xi64>
+
+  // CHECK: linalg.generic
   // CHECK: arith.constant 0
   // CHECK: arith.cmpf
-  %21 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xi1>
+  %22 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xi1>
 
   // CHECK: linalg.generic
   // CHECK: arith.truncf
-  %22 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xf16>
+  %23 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xf16>
 
   // CHECK: linalg.generic
   // CHECK: arith.divf
-  %23 = tosa.reciprocal %0 : (tensor<1xf32>) -> tensor<1xf32>
+  %24 = tosa.reciprocal %0 : (tensor<1xf32>) -> tensor<1xf32>
 
   // CHECK: linalg.generic
   // CHECK: math.erf
-  %24 = tosa.erf %0 : (tensor<1xf32>) -> tensor<1xf32>
+  %25 = tosa.erf %0 : (tensor<1xf32>) -> tensor<1xf32>
 
   return
 }

--- a/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg.mlir
+++ b/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg.mlir
@@ -562,24 +562,24 @@ func.func @test_simple_f32(%arg0: tensor<1xf32>) -> () {
   // CHECK: [[CONV:%.+]] = arith.fptosi [[MAX]] : f32 to i64
   // CHECK: [[CMP:%.+]] = arith.cmpf uge, [[ROUND]], [[CSTMAXP1]] : f32
   // CHECK: arith.select [[CMP]], [[CSTMAX]], [[CONV]] : i64
-  %21 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xi64>
+  %cast_f32_i64 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xi64>
 
   // CHECK: linalg.generic
   // CHECK: arith.constant 0
   // CHECK: arith.cmpf
-  %22 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xi1>
+  %21 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xi1>
 
   // CHECK: linalg.generic
   // CHECK: arith.truncf
-  %23 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xf16>
+  %22 = tosa.cast %0 : (tensor<1xf32>) -> tensor<1xf16>
 
   // CHECK: linalg.generic
   // CHECK: arith.divf
-  %24 = tosa.reciprocal %0 : (tensor<1xf32>) -> tensor<1xf32>
+  %23 = tosa.reciprocal %0 : (tensor<1xf32>) -> tensor<1xf32>
 
   // CHECK: linalg.generic
   // CHECK: math.erf
-  %25 = tosa.erf %0 : (tensor<1xf32>) -> tensor<1xf32>
+  %24 = tosa.erf %0 : (tensor<1xf32>) -> tensor<1xf32>
 
   return
 }


### PR DESCRIPTION
In lowering a tosa.cast op from float to signed int, the float is compared against INT_MAX to check for overflow. The 1 + INT_MAX(width) constant is converted to floating-point, and comparison with it is done in FP. 

However, an intermediate `int64_t` type is used, which overflows and turns 1 + INT_MAX(64) negative when the destination type is `i64`. This PR uses `uint64_t` instead (with `getZExtValue`) so that 1 + INT_MAX stays in bounds and is correctly represented as floating-point.