### PR TITLE
Allow to specify `#once` on .pdll to enable better modular "header" inclusion 

### DIFF
--- a/mlir/include/mlir/Tools/PDLL/Parser/Parser.h
+++ b/mlir/include/mlir/Tools/PDLL/Parser/Parser.h
@@ -29,12 +29,15 @@ class Module;
 /// Parse an AST module from the main file of the given source manager.
 /// `enableDocumentation` is an optional flag that, when set, indicates that the
 /// parser should also include documentation when building the AST when
-/// possible. `codeCompleteContext` is an optional code completion context that
+/// possible. `emitWarningOnRepeatedIncludeAtMainFile` is an optional flag that
+/// allows the parser to emit warnings when include files are repeated at main
+/// file. `codeCompleteContext` is an optional code completion context that
 /// may be provided to receive code completion suggestions. If a completion is
 /// hit, this method returns a failure.
 FailureOr<ast::Module *>
 parsePDLLAST(ast::Context &ctx, llvm::SourceMgr &sourceMgr,
              bool enableDocumentation = false,
+             bool emitWarningOnRepeatedIncludeAtMainFile = false,
              CodeCompleteContext *codeCompleteContext = nullptr);
 } // namespace pdll
 } // namespace mlir

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
@@ -14,6 +14,9 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/SourceMgr.h"
 
+#include <filesystem>
+#include <system_error>
+
 using namespace mlir;
 using namespace mlir::pdll;
 

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.h
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.h
@@ -246,8 +246,9 @@ private:
   /// The optional code completion point within the input file.
   const char *codeCompletionLocation;
 
-  // Allows to keep track of the stack of included files
-  llvm::SmallVector<std::string> includeFileStack;
+  // Allows to keep track of the stack of included files. These paths are stored
+  // in its canonicalized form
+  llvm::SmallVector<std::string> canonicalIncludeFileStack;
 };
 } // namespace pdll
 } // namespace mlir

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.h
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.h
@@ -10,6 +10,7 @@
 #define LIB_TOOLS_PDLL_PARSER_LEXER_H_
 
 #include "mlir/Support/LLVM.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/SMLoc.h"
 
@@ -192,12 +193,21 @@ public:
   /// opened, success otherwise.
   LogicalResult pushInclude(StringRef filename, SMRange includeLoc);
 
+  /// Returns the top include file entry from the stack
+  StringRef getCurrentInclude() const;
+
+  /// Returns wether we are lexing the main file
+  bool isLexingMainFile() const;
+
   /// Lex the next token and return it.
   Token lexToken();
 
   /// Change the position of the lexer cursor. The next token we lex will start
   /// at the designated point in the input.
   void resetPointer(const char *newPointer) { curPtr = newPointer; }
+
+  /// Print a warning
+  void emitWarning(SMRange loc, const Twine &msg);
 
   /// Emit an error to the lexer with the given location and message.
   Token emitError(SMRange loc, const Twine &msg);
@@ -235,6 +245,9 @@ private:
 
   /// The optional code completion point within the input file.
   const char *codeCompletionLocation;
+
+  // Allows to keep track of the stack of included files
+  llvm::SmallVector<std::string> includeFileStack;
 };
 } // namespace pdll
 } // namespace mlir

--- a/mlir/lib/Tools/mlir-pdll-lsp-server/PDLLServer.cpp
+++ b/mlir/lib/Tools/mlir-pdll-lsp-server/PDLLServer.cpp
@@ -393,7 +393,8 @@ PDLDocument::PDLDocument(const lsp::URIForFile &uri, StringRef contents,
     if (auto lspDiag = getLspDiagnoticFromDiag(sourceMgr, diag, uri))
       diagnostics.push_back(std::move(*lspDiag));
   });
-  astModule = parsePDLLAST(astContext, sourceMgr, /*enableDocumentation=*/true);
+  astModule = parsePDLLAST(astContext, sourceMgr, /*enableDocumentation=*/true,
+                           /*emitWarningOnRepeatedIncludeAtMainFile=*/true);
 
   // Initialize the set of parsed includes.
   lsp::gatherIncludeFiles(sourceMgr, parsedIncludes);
@@ -989,6 +990,7 @@ PDLDocument::getCodeCompletion(const lsp::URIForFile &uri,
 
   ast::Context tmpContext(tmpODSContext);
   (void)parsePDLLAST(tmpContext, sourceMgr, /*enableDocumentation=*/true,
+                     /*emitWarningOnRepeatedIncludeAtMainFile=*/true,
                      &lspCompleteContext);
 
   return completionList;
@@ -1144,6 +1146,7 @@ lsp::SignatureHelp PDLDocument::getSignatureHelp(const lsp::URIForFile &uri,
 
   ast::Context tmpContext(tmpODSContext);
   (void)parsePDLLAST(tmpContext, sourceMgr, /*enableDocumentation=*/true,
+                     /*emitWarningOnRepeatedIncludeAtMainFile=*/true,
                      &completeContext);
 
   return signatureHelp;

--- a/mlir/test/mlir-pdll/Parser/include-file-and-file-which-includes-first-file-with-once-00.pdll
+++ b/mlir/test/mlir-pdll/Parser/include-file-and-file-which-includes-first-file-with-once-00.pdll
@@ -1,4 +1,4 @@
-// RUN: mlir-pdll %s -I %S 2>&1 | FileCheck %s
+// RUN: mlir-pdll -emit-warning-for-repeated-includes %s -I %S 2>&1 | FileCheck %s
 
 #include "include/include-file-with-include.pdll"
 // CHECK: warning: included file is already included, and therefore has no effect

--- a/mlir/test/mlir-pdll/Parser/include-file-and-file-which-includes-first-file-with-once-00.pdll
+++ b/mlir/test/mlir-pdll/Parser/include-file-and-file-which-includes-first-file-with-once-00.pdll
@@ -1,0 +1,11 @@
+// RUN: mlir-pdll %s -I %S 2>&1 | FileCheck %s
+
+#include "include/include-file-with-include.pdll"
+// CHECK: warning: included file is already included, and therefore has no effect
+#include "include/included-with-once.pdll"
+
+// CHECK: Module
+// CHECK: |-UserConstraintDecl {{.*}} Name<foo> ResultType<Tuple<>>
+// CHECK: | `-CompoundStmt
+// CHECK: `-UserConstraintDecl {{.*}} Name<bar> ResultType<Tuple<>>
+// CHECK:   `-CompoundStmt

--- a/mlir/test/mlir-pdll/Parser/include-file-and-file-which-includes-first-file-with-once-01.pdll
+++ b/mlir/test/mlir-pdll/Parser/include-file-and-file-which-includes-first-file-with-once-01.pdll
@@ -1,7 +1,8 @@
-// RUN: mlir-pdll %s -I %S 2>&1 | FileCheck %s
+// RUN: mlir-pdll -emit-warning-for-repeated-includes %s -I %S 2>&1 | FileCheck %s
 
 #include "include/included-with-once.pdll"
 #include "include/include-file-with-include.pdll"
+// CHECK-NOT: warning
 
 // CHECK: Module
 // CHECK: |-UserConstraintDecl {{.*}} Name<foo> ResultType<Tuple<>>

--- a/mlir/test/mlir-pdll/Parser/include-file-and-file-which-includes-first-file-with-once-01.pdll
+++ b/mlir/test/mlir-pdll/Parser/include-file-and-file-which-includes-first-file-with-once-01.pdll
@@ -1,0 +1,10 @@
+// RUN: mlir-pdll %s -I %S 2>&1 | FileCheck %s
+
+#include "include/included-with-once.pdll"
+#include "include/include-file-with-include.pdll"
+
+// CHECK: Module
+// CHECK: |-UserConstraintDecl {{.*}} Name<foo> ResultType<Tuple<>>
+// CHECK: | `-CompoundStmt
+// CHECK: `-UserConstraintDecl {{.*}} Name<bar> ResultType<Tuple<>>
+// CHECK:   `-CompoundStmt

--- a/mlir/test/mlir-pdll/Parser/include-file-twice-with-once.pdll
+++ b/mlir/test/mlir-pdll/Parser/include-file-twice-with-once.pdll
@@ -1,0 +1,9 @@
+// RUN: mlir-pdll %s -I %S 2>&1 | FileCheck %s
+
+#include "include/included-with-once.pdll"
+// CHECK: warning: included file is already included, and therefore has no effect
+#include "include/included-with-once.pdll"
+
+// CHECK: Module
+// CHECK: `-UserConstraintDecl {{.*}} Name<foo> ResultType<Tuple<>>
+// CHECK:   `-CompoundStmt

--- a/mlir/test/mlir-pdll/Parser/include-file-twice-with-once.pdll
+++ b/mlir/test/mlir-pdll/Parser/include-file-twice-with-once.pdll
@@ -1,4 +1,4 @@
-// RUN: mlir-pdll %s -I %S 2>&1 | FileCheck %s
+// RUN: mlir-pdll -emit-warning-for-repeated-includes %s -I %S 2>&1 | FileCheck %s
 
 #include "include/included-with-once.pdll"
 // CHECK: warning: included file is already included, and therefore has no effect

--- a/mlir/test/mlir-pdll/Parser/include-file-twice-without-once.pdll
+++ b/mlir/test/mlir-pdll/Parser/include-file-twice-without-once.pdll
@@ -1,0 +1,5 @@
+// RUN: not mlir-pdll %s -I %S 2>&1 | FileCheck %s
+
+#include "include/included.pdll"
+// CHECK: error: `IncludedPattern` has already been defined
+#include "include/included.pdll"

--- a/mlir/test/mlir-pdll/Parser/include/include-file-with-include.pdll
+++ b/mlir/test/mlir-pdll/Parser/include/include-file-with-include.pdll
@@ -1,0 +1,5 @@
+#once
+
+#include "include/included-with-once.pdll"
+
+Constraint bar() {}

--- a/mlir/test/mlir-pdll/Parser/include/included-with-once.pdll
+++ b/mlir/test/mlir-pdll/Parser/include/included-with-once.pdll
@@ -1,0 +1,5 @@
+// This file is included by several including .pdll test files.
+
+#once
+
+Constraint foo() {}


### PR DESCRIPTION
This eases developing .pdll files with the help of `mlir-pdll-lsp-server` 