### PR TITLE
PDLL builtins: Allow float log2 to return even if the log2 is not exact

### DIFF
--- a/mlir/lib/Dialect/PDL/IR/Builtins.cpp
+++ b/mlir/lib/Dialect/PDL/IR/Builtins.cpp
@@ -169,7 +169,7 @@ LogicalResult static unaryOp(PatternRewriter &rewriter, PDLResultList &results,
     } else if constexpr (T == UnaryOpKind::log2) {
       results.push_back(rewriter.getFloatAttr(
           operandFloatAttr.getType(),
-          (double)operandFloatAttr.getValue().getExactLog2()));
+          std::log2(operandFloatAttr.getValueAsDouble())));
     } else if constexpr (T == UnaryOpKind::abs) {
       auto resultVal = operandFloatAttr.getValue();
       resultVal.clearSign();

--- a/mlir/unittests/Dialect/PDL/BuiltinTest.cpp
+++ b/mlir/unittests/Dialect/PDL/BuiltinTest.cpp
@@ -634,6 +634,18 @@ TEST_F(BuiltinTest, log2) {
         cast<FloatAttr>(result.cast<Attribute>()).getValue().convertToFloat(),
         2.0);
   }
+  
+  auto threeF16 = rewriter.getF16FloatAttr(3.0);
+
+  // check correctness
+  {
+    TestPDLResultList results(1);
+    EXPECT_TRUE(builtin::log2(rewriter, results, {threeF16}).succeeded());
+
+    PDLValue result = results.getResults()[0];
+    float resultVal = cast<FloatAttr>(result.cast<Attribute>()).getValue().convertToFloat();
+    EXPECT_TRUE(resultVal > 1.58 && resultVal < 1.59);
+  }
 }
 
 TEST_F(BuiltinTest, exp2) {


### PR DESCRIPTION
Until now log2 was returning either the exact log2 value or min_int. It's been an issue for some computations we make, so I'm changing this behaviour. 