### PR TITLE
[mlir][EmitC] Fix call ops with zero arguments in func to emitc conversion (llvm#94936)

### DIFF
--- a/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
+++ b/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
@@ -37,16 +37,13 @@ public:
           callOp, "only functions with zero or one result can be converted");
 
     // Convert the original function results.
-    Type resultTy = nullptr;
-    if (callOp.getNumResults()) {
-      resultTy = typeConverter->convertType(callOp.getResult(0).getType());
-      if (!resultTy)
-        return rewriter.notifyMatchFailure(
-            callOp, "function return type conversion failed");
+    SmallVector<Type> types;
+    if (failed(typeConverter->convertTypes(callOp.getResultTypes(), types))) {
+      return rewriter.notifyMatchFailure(
+          callOp, "function return type conversion failed");
     }
-
     rewriter.replaceOpWithNewOp<emitc::CallOp>(
-        callOp, resultTy, adaptor.getOperands(), callOp->getAttrs());
+        callOp, types, adaptor.getOperands(), callOp->getAttrs());
 
     return success();
   }

--- a/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
+++ b/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
@@ -31,7 +31,7 @@ public:
   LogicalResult
   matchAndRewrite(func::CallOp callOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Multiple results func was not converted to `emitc.func`.
+    // Multiple results func cannot be converted to `emitc.func`.
     if (callOp.getNumResults() > 1)
       return rewriter.notifyMatchFailure(
           callOp, "only functions with zero or one result can be converted");

--- a/mlir/test/Conversion/FuncToEmitC/func-to-emitc.mlir
+++ b/mlir/test/Conversion/FuncToEmitC/func-to-emitc.mlir
@@ -88,3 +88,19 @@ func.func @index_args_only(%i: index) -> f32 {
   %0 = arith.constant 0.0 : f32
   return %0 : f32
 }
+
+// -----
+
+// CHECK-LABEL: emitc.func private @return_void() attributes {specifiers = ["static"]}
+// CHECK-NEXT: emitc.return
+func.func private @return_void() {
+  return
+}
+
+// CHECK-LABEL: emitc.func @call()
+// CHECK-NEXT: emitc.call @return_void() : () -> ()
+// CHECK-NEXT: emitc.return
+func.func @call() {
+  call @return_void() : () -> ()
+  return
+}


### PR DESCRIPTION
This brings a commit from upstream, plus a fix for a crash in the new test case that was caused by https://github.com/Xilinx/llvm-project/pull/186/files#diff-6117a54260c78d69ee5216fa6487bd5290618438442f46b45c6715653938baae setting the resultTypes to nullptr instead of using an empty range.