### PR TITLE
Reconcile EmitC changes with upstream

### DIFF
--- a/mlir/docs/Dialects/emitc.md
+++ b/mlir/docs/Dialects/emitc.md
@@ -10,10 +10,17 @@ The following convention is followed:
     `emitc.call_opaque` operation, C++11 is required.
 *   If floating-point type template arguments are passed to an `emitc.call_opaque`
     operation, C++20 is required.
+*   If `ssize_t` is used, then the code requires the POSIX header `sys/types.h`
+    or any of the C++ headers in which the type is defined.
 *   Else the generated code is compatible with C99.
 
 These restrictions are neither inherent to the EmitC dialect itself nor to the
 Cpp emitter and therefore need to be considered while implementing conversions.
+
+Type conversions are provided for the MLIR type `index` into the unsigned `size_t`
+type and its signed counterpart `ptrdiff_t`. Conversions between these two types
+are only valid if the `index`-typed values are within 
+`[PTRDIFF_MIN, PTRDIFF_MAX]`.
 
 After the conversion, C/C++ code can be emitted with `mlir-translate`. The tool
 supports translating MLIR to C/C++ by passing `-mlir-to-cpp`. Furthermore, code

--- a/mlir/include/mlir/Conversion/ArithToEmitC/ArithToEmitC.h
+++ b/mlir/include/mlir/Conversion/ArithToEmitC/ArithToEmitC.h
@@ -13,8 +13,8 @@ namespace mlir {
 class RewritePatternSet;
 class TypeConverter;
 
-void populateArithToEmitCPatterns(RewritePatternSet &patterns,
-                                  TypeConverter &typeConverter);
+void populateArithToEmitCPatterns(TypeConverter &typeConverter,
+                                  RewritePatternSet &patterns);
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_ARITHTOEMITC_ARITHTOEMITC_H

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
@@ -45,7 +45,7 @@ bool isIntegerIndexOrOpaqueType(Type type);
 bool isSupportedFloatType(mlir::Type type);
 
 /// Determines whether \p type is a emitc.size_t/ssize_t type.
-bool isAnySizeTType(mlir::Type type);
+bool isPointerWideType(mlir::Type type);
 
 } // namespace emitc
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -51,8 +51,8 @@ class EmitC_BinaryOp<string mnemonic, list<Trait> traits = []> :
 def CExpression : NativeOpTrait<"emitc::CExpression">;
 
 // Types only used in binary arithmetic operations.
-def IntegerIndexOrOpaqueType : AnyTypeOf<[EmitCIntegerType, Index,
-  EmitC_SignedSizeT, EmitC_SizeT, EmitC_OpaqueType]>;
+def IntegerIndexOrOpaqueType : Type<CPred<"emitc::isIntegerIndexOrOpaqueType($_self)">,
+"integer, index or opaque type supported by EmitC">;
 def FloatIntegerIndexOrOpaqueType : AnyTypeOf<[EmitCFloatType, IntegerIndexOrOpaqueType]>;
 
 def EmitC_AddOp : EmitC_BinaryOp<"add", [CExpression]> {
@@ -288,7 +288,6 @@ def EmitC_CastOp : EmitC_Op<"cast",
   let arguments = (ins EmitCType:$source);
   let results = (outs EmitCType:$dest);
   let assemblyFormat = "$source attr-dict `:` type($source) `to` type($dest)";
-  let hasFolder = 1;
 }
 
 def EmitC_CmpOp : EmitC_BinaryOp<"cmp", [CExpression]> {

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitCTypes.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitCTypes.td
@@ -75,9 +75,9 @@ def EmitC_ArrayType : EmitC_Type<"Array", "array", [ShapedTypeInterface]> {
                         Type elementType) const;
 
     static bool isValidElementType(Type type) {
-      return type.isIntOrIndexOrFloat() ||
-         emitc::isAnySizeTType(type) ||
-         llvm::isa<PointerType, OpaqueType>(type);
+      return emitc::isSupportedFloatType(type) ||
+         emitc::isIntegerIndexOrOpaqueType(type) ||
+         llvm::isa<PointerType>(type);
     }
   }];
   let genVerifyDecl = 1;
@@ -133,10 +133,29 @@ def EmitC_PointerType : EmitC_Type<"Pointer", "ptr"> {
 
 def EmitC_SignedSizeT : EmitC_Type<"SignedSizeT", "ssize_t"> {
   let summary = "EmitC signed size type";
+  let description = [{
+    Data type representing all values of `emitc.size_t`, plus -1.
+    It corresponds to `ssize_t` found in `<sys/types.h>`.
+    
+    Use of this type causes the code to be non-C99 compliant.
+  }];
+}
+
+def EmitC_PtrDiffT : EmitC_Type<"PtrDiffT", "ptrdiff_t"> {
+  let summary = "EmitC signed pointer diff type";
+  let description = [{
+    Signed data type as wide as platform-specific pointer types.
+    In particular, it is as wide as `emitc.size_t`.
+    It corresponds to `ptrdiff_t` found in `<stddef.h>`.
+  }];
 }
 
 def EmitC_SizeT : EmitC_Type<"SizeT", "size_t"> {
   let summary = "EmitC unsigned size type";
+  let description = [{
+    Unsigned data type as wide as platform-specific pointer types.
+    It corresponds to `size_t` found in `<stddef.h>`.
+  }];
 }
 
 #endif // MLIR_DIALECT_EMITC_IR_EMITCTYPES

--- a/mlir/include/mlir/Dialect/EmitC/Transforms/TypeConversions.h
+++ b/mlir/include/mlir/Dialect/EmitC/Transforms/TypeConversions.h
@@ -11,7 +11,8 @@
 
 namespace mlir {
 class TypeConverter;
-void populateEmitCSizeTypeConversions(TypeConverter &converter);
+void populateEmitCSizeTTypeConversions(TypeConverter &converter);
+
 } // namespace mlir
 
 #endif // MLIR_DIALECT_EMITC_TRANSFORMS_TYPECONVERSIONS_H

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -18,8 +18,6 @@
 #include "mlir/Dialect/EmitC/Transforms/TypeConversions.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Region.h"
-#include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 using namespace mlir;
@@ -47,41 +45,29 @@ public:
   }
 };
 
-/// Return an operation that returns true (in i1) when operand is NaN.
-emitc::CmpOp isNan(ConversionPatternRewriter &rewriter, Location loc,
-                   Value operand) {
-  // A value is NaN exactly when it compares unequal to itself.
-  return rewriter.create<emitc::CmpOp>(
-      loc, rewriter.getI1Type(), emitc::CmpPredicate::ne, operand, operand);
+/// Get the signed or unsigned type corresponding to \p ty.
+Type adaptIntegralTypeSignedness(Type ty, bool needsUnsigned) {
+  if (isa<IntegerType>(ty)) {
+    if (ty.isUnsignedInteger() != needsUnsigned) {
+      auto signedness = needsUnsigned
+                            ? IntegerType::SignednessSemantics::Unsigned
+                            : IntegerType::SignednessSemantics::Signed;
+      return IntegerType::get(ty.getContext(), ty.getIntOrFloatBitWidth(),
+                              signedness);
+    }
+  } else if (emitc::isPointerWideType(ty)) {
+    if (isa<emitc::SizeTType>(ty) != needsUnsigned) {
+      if (needsUnsigned)
+        return emitc::SizeTType::get(ty.getContext());
+      return emitc::PtrDiffTType::get(ty.getContext());
+    }
+  }
+  return ty;
 }
 
-/// Return an operation that returns true (in i1) when operand is not NaN.
-emitc::CmpOp isNotNan(ConversionPatternRewriter &rewriter, Location loc,
-                      Value operand) {
-  // A value is not NaN exactly when it compares equal to itself.
-  return rewriter.create<emitc::CmpOp>(
-      loc, rewriter.getI1Type(), emitc::CmpPredicate::eq, operand, operand);
-}
-
-/// Return an op that return true (in i1) if the operands \p first and \p second
-/// are unordered (i.e., at least one of them is NaN).
-emitc::LogicalOrOp createCheckIsUnordered(ConversionPatternRewriter &rewriter,
-                                          Location loc, Value first,
-                                          Value second) {
-  auto firstIsNaN = isNan(rewriter, loc, first);
-  auto secondIsNaN = isNan(rewriter, loc, second);
-  return rewriter.create<emitc::LogicalOrOp>(loc, rewriter.getI1Type(),
-                                             firstIsNaN, secondIsNaN);
-}
-
-/// Return an op that return true (in i1) if the operands \p first and \p second
-/// are both ordered (i.e., none one of them is NaN).
-Value createCheckIsOrdered(ConversionPatternRewriter &rewriter, Location loc,
-                           Value first, Value second) {
-  auto firstIsNaN = isNotNan(rewriter, loc, first);
-  auto secondIsNaN = isNotNan(rewriter, loc, second);
-  return rewriter.create<emitc::LogicalAndOp>(loc, rewriter.getI1Type(),
-                                              firstIsNaN, secondIsNaN);
+/// Insert a cast operation to type \p ty if \p val does not have this type.
+Value adaptValueType(Value val, ConversionPatternRewriter &rewriter, Type ty) {
+  return rewriter.createOrFold<emitc::CastOp>(val.getLoc(), ty, val);
 }
 
 class CmpFOpConversion : public OpConversionPattern<arith::CmpFOp> {
@@ -113,7 +99,6 @@ public:
       predicate = emitc::CmpPredicate::eq;
       break;
     case arith::CmpFPredicate::OGT:
-      // ordered and greater than
       unordered = false;
       predicate = emitc::CmpPredicate::gt;
       break;
@@ -141,27 +126,22 @@ public:
       return success();
     }
     case arith::CmpFPredicate::UEQ:
-      // unordered or equal
       unordered = true;
       predicate = emitc::CmpPredicate::eq;
       break;
     case arith::CmpFPredicate::UGT:
-      // unordered or greater than
       unordered = true;
       predicate = emitc::CmpPredicate::gt;
       break;
     case arith::CmpFPredicate::UGE:
-      // unordered or greater equal
       unordered = true;
       predicate = emitc::CmpPredicate::ge;
       break;
     case arith::CmpFPredicate::ULT:
-      // unordered or less than
       unordered = true;
       predicate = emitc::CmpPredicate::lt;
       break;
     case arith::CmpFPredicate::ULE:
-      // unordered or less than
       unordered = true;
       predicate = emitc::CmpPredicate::le;
       break;
@@ -194,8 +174,8 @@ public:
     if (unordered) {
       auto isUnordered = createCheckIsUnordered(
           rewriter, op.getLoc(), adaptor.getLhs(), adaptor.getRhs());
-      rewriter.replaceOpWithNewOp<emitc::LogicalOrOp>(
-          op, op.getType(), isUnordered.getResult(), cmpResult);
+      rewriter.replaceOpWithNewOp<emitc::LogicalOrOp>(op, op.getType(),
+                                                      isUnordered, cmpResult);
       return success();
     }
 
@@ -205,36 +185,44 @@ public:
                                                      isOrdered, cmpResult);
     return success();
   }
-};
 
-/// Check if the signedness of type \p ty matches the expected
-/// signedness, and issue a type with the correct signedness if
-/// necessary.
-Type adaptIntegralTypeSignedness(Type ty, bool needsUnsigned) {
-  if (isa<IntegerType>(ty)) {
-    // Turns signless integers into signed integers.
-    if (ty.isUnsignedInteger() != needsUnsigned) {
-      auto signedness = needsUnsigned
-                            ? IntegerType::SignednessSemantics::Unsigned
-                            : IntegerType::SignednessSemantics::Signed;
-      return IntegerType::get(ty.getContext(), ty.getIntOrFloatBitWidth(),
-                              signedness);
-    }
-  } else if (emitc::isAnySizeTType(ty)) {
-    if (isa<emitc::SizeTType>(ty) != needsUnsigned) {
-      if (needsUnsigned)
-        return emitc::SizeTType::get(ty.getContext());
-      return emitc::SignedSizeTType::get(ty.getContext());
-    }
+private:
+  /// Return a value that is true if \p operand is NaN.
+  Value isNaN(ConversionPatternRewriter &rewriter, Location loc,
+              Value operand) const {
+    // A value is NaN exactly when it compares unequal to itself.
+    return rewriter.create<emitc::CmpOp>(
+        loc, rewriter.getI1Type(), emitc::CmpPredicate::ne, operand, operand);
   }
-  return ty;
-}
 
-/// Insert a cast operation to type \p ty if \p val
-/// does not have this type.
-Value adaptValueType(Value val, ConversionPatternRewriter &rewriter, Type ty) {
-  return rewriter.createOrFold<emitc::CastOp>(val.getLoc(), ty, val);
-}
+  /// Return a value that is true if \p operand is not NaN.
+  Value isNotNaN(ConversionPatternRewriter &rewriter, Location loc,
+                 Value operand) const {
+    // A value is not NaN exactly when it compares equal to itself.
+    return rewriter.create<emitc::CmpOp>(
+        loc, rewriter.getI1Type(), emitc::CmpPredicate::eq, operand, operand);
+  }
+
+  /// Return a value that is true if the operands \p first and \p second are
+  /// unordered (i.e., at least one of them is NaN).
+  Value createCheckIsUnordered(ConversionPatternRewriter &rewriter,
+                               Location loc, Value first, Value second) const {
+    auto firstIsNaN = isNaN(rewriter, loc, first);
+    auto secondIsNaN = isNaN(rewriter, loc, second);
+    return rewriter.create<emitc::LogicalOrOp>(loc, rewriter.getI1Type(),
+                                               firstIsNaN, secondIsNaN);
+  }
+
+  /// Return a value that is true if the operands \p first and \p second are
+  /// both ordered (i.e., none one of them is NaN).
+  Value createCheckIsOrdered(ConversionPatternRewriter &rewriter, Location loc,
+                             Value first, Value second) const {
+    auto firstIsNotNaN = isNotNaN(rewriter, loc, first);
+    auto secondIsNotNaN = isNotNaN(rewriter, loc, second);
+    return rewriter.create<emitc::LogicalAndOp>(loc, rewriter.getI1Type(),
+                                                firstIsNotNaN, secondIsNotNaN);
+  }
+};
 
 class CmpIOpConversion : public OpConversionPattern<arith::CmpIOp> {
 public:
@@ -285,10 +273,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     Type type = adaptor.getLhs().getType();
-    if (!isa_and_nonnull<IntegerType, emitc::SignedSizeTType, emitc::SizeTType>(
-            type)) {
+    if (!type || !(isa<IntegerType>(type) || emitc::isPointerWideType(type))) {
       return rewriter.notifyMatchFailure(
-          op, "expected integer or size_t/ssize_t type");
+          op, "expected integer or size_t/ssize_t/ptrdiff_t type");
     }
 
     bool needsUnsigned = needsUnsignedCmp(op.getPredicate());
@@ -314,10 +301,15 @@ public:
     auto adaptedOp = adaptor.getOperand();
     auto adaptedOpType = adaptedOp.getType();
 
-    if (!isa<FloatType>(adaptedOpType)) {
-      return rewriter.notifyMatchFailure(op.getLoc(),
-                                         "negf currently only supported on "
-                                         "floats, not tensors/vectors thereof");
+    if (isa<TensorType>(adaptedOpType) || isa<VectorType>(adaptedOpType)) {
+      return rewriter.notifyMatchFailure(
+          op.getLoc(),
+          "negf currently only supports scalar types, not vectors or tensors");
+    }
+
+    if (!emitc::isSupportedFloatType(adaptedOpType)) {
+      return rewriter.notifyMatchFailure(
+          op.getLoc(), "floating-point type is not supported by EmitC");
     }
 
     rewriter.replaceOpWithNewOp<emitc::UnaryMinusOp>(op, adaptedOpType,
@@ -336,10 +328,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     Type opReturnType = this->getTypeConverter()->convertType(op.getType());
-    if (!isa_and_nonnull<IntegerType, emitc::SignedSizeTType, emitc::SizeTType>(
-            opReturnType))
+    if (!opReturnType || !(isa<IntegerType>(opReturnType) ||
+                           emitc::isPointerWideType(opReturnType)))
       return rewriter.notifyMatchFailure(
-          op, "expected integer or size_t/ssize_t result type");
+          op, "expected integer or size_t/ssize_t/ptrdiff_t result type");
 
     if (adaptor.getOperands().size() != 1) {
       return rewriter.notifyMatchFailure(
@@ -347,20 +339,25 @@ public:
     }
 
     Type operandType = adaptor.getIn().getType();
-    if (!isa_and_nonnull<IntegerType, emitc::SignedSizeTType, emitc::SizeTType>(
-            operandType))
+    if (!operandType || !(isa<IntegerType>(operandType) ||
+                          emitc::isPointerWideType(operandType)))
       return rewriter.notifyMatchFailure(
-          op, "expected integer or size_t/ssize_t operand type");
+          op, "expected integer or size_t/ssize_t/ptrdiff_t operand type");
+
+    // Signed (sign-extending) casts from i1 are not supported.
+    if (operandType.isInteger(1) && !castToUnsigned)
+      return rewriter.notifyMatchFailure(op,
+                                         "operation not supported on i1 type");
 
     // to-i1 conversions: arith semantics want truncation, whereas (bool)(v) is
     // equivalent to (v != 0). Implementing as (bool)(v & 0x01) gives
     // truncation.
     if (opReturnType.isInteger(1)) {
-      Type attrType = (emitc::isAnySizeTType(operandType))
+      Type attrType = (emitc::isPointerWideType(operandType))
                           ? rewriter.getIndexType()
                           : operandType;
       auto constOne = rewriter.create<emitc::ConstantOp>(
-          op.getLoc(), operandType, rewriter.getIntegerAttr(attrType, 1));
+          op.getLoc(), operandType, rewriter.getOneAttr(attrType));
       auto oneAndOperand = rewriter.create<emitc::BitwiseAndOp>(
           op.getLoc(), operandType, adaptor.getIn(), constOne);
       rewriter.replaceOpWithNewOp<emitc::CastOp>(op, opReturnType,
@@ -466,10 +463,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     Type type = this->getTypeConverter()->convertType(op.getType());
-    if (!isa_and_nonnull<IntegerType, emitc::SignedSizeTType, emitc::SizeTType>(
-            type)) {
+    if (!type || !(isa<IntegerType>(type) || emitc::isPointerWideType(type))) {
       return rewriter.notifyMatchFailure(
-          op, "expected integer or size_t/ssize_t type");
+          op, "expected integer or size_t/ssize_t/ptrdiff_t type");
     }
 
     if (type.isInteger(1)) {
@@ -510,11 +506,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     Type type = this->getTypeConverter()->convertType(op.getType());
-    if (!isa_and_nonnull<IntegerType, emitc::SignedSizeTType, emitc::SizeTType>(
-            type)) {
+    if (!isa_and_nonnull<IntegerType>(type)) {
       return rewriter.notifyMatchFailure(
-          op, "expected integer or size_t/ssize_t type, vector/tensor support "
-              "not yet implemented");
+          op,
+          "expected integer type, vector/tensor support not yet implemented");
     }
 
     // Bitwise ops can be performed directly on booleans
@@ -551,10 +546,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     Type type = this->getTypeConverter()->convertType(op.getType());
-    if (!isa_and_nonnull<IntegerType, emitc::SignedSizeTType, emitc::SizeTType>(
-            type)) {
+    if (!type || !(isa<IntegerType>(type) || emitc::isPointerWideType(type))) {
       return rewriter.notifyMatchFailure(
-          op, "expected integer or size_t/ssize_t type");
+          op, "expected integer or size_t/ssize_t/ptrdiff_t type");
     }
 
     if (type.isInteger(1)) {
@@ -571,11 +565,11 @@ public:
 
     // Add a runtime check for overflow
     Value width;
-    if (isa<emitc::SignedSizeTType, emitc::SizeTType>(type)) {
+    if (emitc::isPointerWideType(type)) {
       Value eight = rewriter.create<emitc::ConstantOp>(
           op.getLoc(), rhsType, rewriter.getIndexAttr(8));
       emitc::CallOpaqueOp sizeOfCall = rewriter.create<emitc::CallOpaqueOp>(
-          op.getLoc(), rhsType, "sizeof", SmallVector<Value, 1>({eight}));
+          op.getLoc(), rhsType, "sizeof", ArrayRef<Value>{eight});
       width = rewriter.create<emitc::MulOp>(op.getLoc(), rhsType, eight,
                                             sizeOfCall.getResult(0));
     } else {
@@ -745,11 +739,11 @@ public:
 // Pattern population
 //===----------------------------------------------------------------------===//
 
-void mlir::populateArithToEmitCPatterns(RewritePatternSet &patterns,
-                                        TypeConverter &typeConverter) {
+void mlir::populateArithToEmitCPatterns(TypeConverter &typeConverter,
+                                        RewritePatternSet &patterns) {
   MLIRContext *ctx = patterns.getContext();
 
-  mlir::populateEmitCSizeTypeConversions(typeConverter);
+  mlir::populateEmitCSizeTTypeConversions(typeConverter);
 
   // clang-format off
   patterns.add<
@@ -757,8 +751,8 @@ void mlir::populateArithToEmitCPatterns(RewritePatternSet &patterns,
     ArithOpConversion<arith::AddFOp, emitc::AddOp>,
     ArithOpConversion<arith::DivFOp, emitc::DivOp>,
     ArithOpConversion<arith::DivSIOp, emitc::DivOp>,
-    ArithOpConversion<arith::RemSIOp, emitc::RemOp>,
     ArithOpConversion<arith::MulFOp, emitc::MulOp>,
+    ArithOpConversion<arith::RemSIOp, emitc::RemOp>,
     ArithOpConversion<arith::SubFOp, emitc::SubOp>,
     BinaryUIOpConversion<arith::DivUIOp, emitc::DivOp>,
     BinaryUIOpConversion<arith::RemUIOp, emitc::RemOp>,

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitCPass.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitCPass.cpp
@@ -16,7 +16,6 @@
 #include "mlir/Conversion/ArithToEmitC/ArithToEmitC.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
-#include "mlir/Dialect/EmitC/Transforms/TypeConversions.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -30,7 +29,6 @@ using namespace mlir;
 namespace {
 struct ConvertArithToEmitC
     : public impl::ConvertArithToEmitCBase<ConvertArithToEmitC> {
-  using Base::Base;
   void runOnOperation() override;
 };
 } // namespace
@@ -44,11 +42,9 @@ void ConvertArithToEmitC::runOnOperation() {
   RewritePatternSet patterns(&getContext());
 
   TypeConverter typeConverter;
-  // Fallback converter
-  // See note https://mlir.llvm.org/docs/DialectConversion/#type-converter
-  // Type converters are called most to least recently inserted
-  typeConverter.addConversion([](Type t) { return t; });
-  populateArithToEmitCPatterns(patterns, typeConverter);
+  typeConverter.addConversion([](Type type) { return type; });
+
+  populateArithToEmitCPatterns(typeConverter, patterns);
 
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))

--- a/mlir/lib/Conversion/FuncToEmitC/FuncToEmitCPass.cpp
+++ b/mlir/lib/Conversion/FuncToEmitC/FuncToEmitCPass.cpp
@@ -39,7 +39,7 @@ void ConvertFuncToEmitC::runOnOperation() {
   // See note https://mlir.llvm.org/docs/DialectConversion/#type-converter
   // Type converters are called most to least recently inserted
   typeConverter.addConversion([](Type t) { return t; });
-  populateEmitCSizeTypeConversions(typeConverter);
+  populateEmitCSizeTTypeConversions(typeConverter);
 
   ConversionTarget target(getContext());
 

--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitCPass.cpp
+++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitCPass.cpp
@@ -40,7 +40,7 @@ struct ConvertMemRefToEmitCPass
     });
 
     populateMemRefToEmitCTypeConversion(converter);
-    populateEmitCSizeTypeConversions(converter);
+    populateEmitCSizeTTypeConversions(converter);
 
     RewritePatternSet patterns(&getContext());
     populateMemRefToEmitCConversionPatterns(patterns, converter);

--- a/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
+++ b/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
@@ -214,7 +214,7 @@ void SCFToEmitCPass::runOnOperation() {
   // See note https://mlir.llvm.org/docs/DialectConversion/#type-converter
   // Type converters are called most to least recently inserted
   typeConverter.addConversion([](Type t) { return t; });
-  populateEmitCSizeTypeConversions(typeConverter);
+  populateEmitCSizeTTypeConversions(typeConverter);
   populateSCFToEmitCConversionPatterns(patterns, typeConverter);
 
   // Configure conversion to lower out SCF operations.

--- a/mlir/lib/Dialect/EmitC/Transforms/TypeConversions.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/TypeConversions.cpp
@@ -29,7 +29,7 @@ std::optional<Value> materializeAsUnrealizedCast(OpBuilder &builder,
 
 } // namespace
 
-void mlir::populateEmitCSizeTypeConversions(TypeConverter &converter) {
+void mlir::populateEmitCSizeTTypeConversions(TypeConverter &converter) {
   converter.addConversion(
       [](IndexType type) { return emitc::SizeTType::get(type.getContext()); });
 

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -1563,10 +1563,12 @@ LogicalResult CppEmitter::emitType(Location loc, Type type) {
   }
   if (auto iType = dyn_cast<IndexType>(type))
     return (os << "size_t"), success();
-  if (auto iType = dyn_cast<emitc::SizeTType>(type))
+  if (auto sType = dyn_cast<emitc::SizeTType>(type))
     return (os << "size_t"), success();
-  if (auto iType = dyn_cast<emitc::SignedSizeTType>(type))
+  if (auto sType = dyn_cast<emitc::SignedSizeTType>(type))
     return (os << "ssize_t"), success();
+  if (auto pType = dyn_cast<emitc::PtrDiffTType>(type))
+    return (os << "ptrdiff_t"), success();
   if (auto tType = dyn_cast<TensorType>(type)) {
     if (!tType.hasRank())
       return emitError(loc, "cannot emit unranked tensor type");

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -61,22 +61,6 @@ func.func @arith_integer_ops(%arg0: i32, %arg1: i32) {
 
 // -----
 
-func.func @arith_signed_integer_div(%arg0: i32, %arg1: i32) {
-  // CHECK: emitc.div %arg0, %arg1 : (i32, i32) -> i32
-  %0 = arith.divsi %arg0, %arg1 : i32
-  return
-}
-
-// -----
-
-func.func @arith_signed_integer_rem(%arg0: i32, %arg1: i32) {
-  // CHECK: emitc.rem %arg0, %arg1 : (i32, i32) -> i32
-  %0 = arith.remsi %arg0, %arg1 : i32
-  return
-}
-
-// -----
-
 // CHECK-LABEL: arith_integer_ops_signed_nsw
 func.func @arith_integer_ops_signed_nsw(%arg0: i32, %arg1: i32) {
   // CHECK: emitc.add %arg0, %arg1 : (i32, i32) -> i32
@@ -117,17 +101,17 @@ func.func @arith_bitwise(%arg0: i32, %arg1: i32) {
   // CHECK: %[[C2:[^ ]*]] = emitc.cast %[[ARG1]] : i32 to ui32
   // CHECK: %[[AND:[^ ]*]] = emitc.bitwise_and %[[C1]], %[[C2]] : (ui32, ui32) -> ui32
   // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[AND]] : ui32 to i32
-  %5 = arith.andi %arg0, %arg1 : i32
+  %0 = arith.andi %arg0, %arg1 : i32
   // CHECK: %[[C1:[^ ]*]] = emitc.cast %[[ARG0]] : i32 to ui32
   // CHECK: %[[C2:[^ ]*]] = emitc.cast %[[ARG1]] : i32 to ui32
   // CHECK: %[[OR:[^ ]*]] = emitc.bitwise_or %[[C1]], %[[C2]] : (ui32, ui32) -> ui32
   // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[OR]] : ui32 to i32
-  %6 = arith.ori %arg0, %arg1 : i32
+  %1 = arith.ori %arg0, %arg1 : i32
   // CHECK: %[[C1:[^ ]*]] = emitc.cast %[[ARG0]] : i32 to ui32
   // CHECK: %[[C2:[^ ]*]] = emitc.cast %[[ARG1]] : i32 to ui32
   // CHECK: %[[XOR:[^ ]*]] = emitc.bitwise_xor %[[C1]], %[[C2]] : (ui32, ui32) -> ui32
   // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[XOR]] : ui32 to i32
-  %7 = arith.xori %arg0, %arg1 : i32
+  %2 = arith.xori %arg0, %arg1 : i32
 
   return
 }
@@ -135,14 +119,26 @@ func.func @arith_bitwise(%arg0: i32, %arg1: i32) {
 // -----
 
 // CHECK-LABEL: arith_bitwise_bool
+// CHECK-SAME: %[[ARG0:.*]]: i1, %[[ARG1:.*]]: i1
 func.func @arith_bitwise_bool(%arg0: i1, %arg1: i1) {
-  // CHECK: %[[AND:[^ ]*]] = emitc.bitwise_and %arg0, %arg1 : (i1, i1) -> i1
-  %5 = arith.andi %arg0, %arg1 : i1
-  // CHECK: %[[OR:[^ ]*]] = emitc.bitwise_or %arg0, %arg1 : (i1, i1) -> i1
-  %6 = arith.ori %arg0, %arg1 : i1
-  // CHECK: %[[xor:[^ ]*]] = emitc.bitwise_xor %arg0, %arg1 : (i1, i1) -> i1
-  %7 = arith.xori %arg0, %arg1 : i1
+  // CHECK: %[[AND:[^ ]*]] = emitc.bitwise_and %[[ARG0]], %[[ARG1]] : (i1, i1) -> i1
+  %0 = arith.andi %arg0, %arg1 : i1
+  // CHECK: %[[OR:[^ ]*]] = emitc.bitwise_or %[[ARG0]], %[[ARG1]] : (i1, i1) -> i1
+  %1 = arith.ori %arg0, %arg1 : i1
+  // CHECK: %[[xor:[^ ]*]] = emitc.bitwise_xor %[[ARG0]], %[[ARG1]] : (i1, i1) -> i1
+  %2 = arith.xori %arg0, %arg1 : i1
+  
+  return
+}
 
+// -----
+
+// CHECK-LABEL: arith_signed_integer_div_rem
+func.func @arith_signed_integer_div_rem(%arg0: i32, %arg1: i32) {
+  // CHECK: emitc.div %arg0, %arg1 : (i32, i32) -> i32
+  %0 = arith.divsi %arg0, %arg1 : i32
+  // CHECK: emitc.rem %arg0, %arg1 : (i32, i32) -> i32
+  %1 = arith.remsi %arg0, %arg1 : i32
   return
 }
 
@@ -203,8 +199,8 @@ func.func @arith_shift_left_index(%amount: i32) {
   %cst0 = "arith.constant"() {value = 42 : index} : () -> (index)
   %cast1 = arith.index_cast %amount : i32 to index
   // CHECK-DAG: %[[C1:[^ ]*]] = "emitc.constant"(){{.*}}value = 42{{.*}}!emitc.size_t
-  // CHECK-DAG: %[[Cast1:[^ ]*]] = emitc.cast %[[AMOUNT]] : i32 to !emitc.ssize_t
-  // CHECK-DAG: %[[AmountIdx:[^ ]*]] = emitc.cast %[[Cast1]] : !emitc.ssize_t to !emitc.size_t
+  // CHECK-DAG: %[[Cast1:[^ ]*]] = emitc.cast %[[AMOUNT]] : i32 to !emitc.ptrdiff_t
+  // CHECK-DAG: %[[AmountIdx:[^ ]*]] = emitc.cast %[[Cast1]] : !emitc.ptrdiff_t to !emitc.size_t
   // CHECK-DAG: %[[Byte:[^ ]*]] = "emitc.constant"{{.*}}value = 8{{.*}}index
   // CHECK-DAG: %[[SizeOf:[^ ]*]] = emitc.call_opaque "sizeof"(%[[Byte]]) : (!emitc.size_t) -> !emitc.size_t
   // CHECK-DAG: %[[SizeConstant:[^ ]*]] = emitc.mul %[[Byte]], %[[SizeOf]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
@@ -224,8 +220,8 @@ func.func @arith_shift_left_index(%amount: i32) {
 // CHECK-SAME: %[[AMOUNT:.*]]: i32
 func.func @arith_shift_right_index(%amount: i32) {
   // CHECK-DAG: %[[C1:[^ ]*]] = "emitc.constant"(){{.*}}value = 42{{.*}}!emitc.size_t
-  // CHECK-DAG: %[[Cast1:[^ ]*]] = emitc.cast %[[AMOUNT]] : i32 to !emitc.ssize_t
-  // CHECK-DAG: %[[AmountIdx:[^ ]*]] = emitc.cast %[[Cast1]] : !emitc.ssize_t to !emitc.size_t
+  // CHECK-DAG: %[[Cast1:[^ ]*]] = emitc.cast %[[AMOUNT]] : i32 to !emitc.ptrdiff_t
+  // CHECK-DAG: %[[AmountIdx:[^ ]*]] = emitc.cast %[[Cast1]] : !emitc.ptrdiff_t to !emitc.size_t
   %arg0 = "arith.constant"() {value = 42 : index} : () -> (index)
   %arg1 = arith.index_cast %amount : i32 to index
 
@@ -240,17 +236,17 @@ func.func @arith_shift_right_index(%amount: i32) {
   // CHECK: emitc.yield %[[Ternary]] : !emitc.size_t
   %2 = arith.shrui %arg0, %arg1 : index
 
-  // CHECK-DAG: %[[SC1:[^ ]*]] = emitc.cast %[[C1]] : !emitc.size_t to !emitc.ssize_t
+  // CHECK-DAG: %[[SC1:[^ ]*]] = emitc.cast %[[C1]] : !emitc.size_t to !emitc.ptrdiff_t
   // CHECK-DAG: %[[SByte:[^ ]*]] = "emitc.constant"{{.*}}value = 8{{.*}}index{{.*}}!emitc.size_t
   // CHECK-DAG: %[[SSizeOf:[^ ]*]] = emitc.call_opaque "sizeof"(%[[SByte]]) : (!emitc.size_t) -> !emitc.size_t
   // CHECK-DAG: %[[SSizeConstant:[^ ]*]] = emitc.mul %[[SByte]], %[[SSizeOf]] : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
   // CHECK-DAG: %[[SCmpNoExcess:[^ ]*]] = emitc.cmp lt, %[[AmountIdx]], %[[SSizeConstant]] : (!emitc.size_t, !emitc.size_t) -> i1
-  // CHECK-DAG: %[[SZero:[^ ]*]] = "emitc.constant"{{.*}}value = 0{{.*}}!emitc.ssize_t
-  // CHECK: %[[SShiftRes:[^ ]*]] = emitc.expression : !emitc.ssize_t
-  // CHECK: %[[SHRSI:[^ ]*]] = emitc.bitwise_right_shift %[[SC1]], %[[AmountIdx]] : (!emitc.ssize_t, !emitc.size_t) -> !emitc.ssize_t
-  // CHECK: %[[STernary:[^ ]*]] = emitc.conditional %[[SCmpNoExcess]], %[[SHRSI]], %[[SZero]] : !emitc.ssize_t
-  // CHECK: emitc.yield %[[STernary]] : !emitc.ssize_t
-  // CHECK: emitc.cast %[[SShiftRes]] : !emitc.ssize_t to !emitc.size_t
+  // CHECK-DAG: %[[SZero:[^ ]*]] = "emitc.constant"{{.*}}value = 0{{.*}}!emitc.ptrdiff_t
+  // CHECK: %[[SShiftRes:[^ ]*]] = emitc.expression : !emitc.ptrdiff_t
+  // CHECK: %[[SHRSI:[^ ]*]] = emitc.bitwise_right_shift %[[SC1]], %[[AmountIdx]] : (!emitc.ptrdiff_t, !emitc.size_t) -> !emitc.ptrdiff_t
+  // CHECK: %[[STernary:[^ ]*]] = emitc.conditional %[[SCmpNoExcess]], %[[SHRSI]], %[[SZero]] : !emitc.ptrdiff_t
+  // CHECK: emitc.yield %[[STernary]] : !emitc.ptrdiff_t
+  // CHECK: emitc.cast %[[SShiftRes]] : !emitc.ptrdiff_t to !emitc.size_t
   %3 = arith.shrsi %arg0, %arg1 : index
 
   return
@@ -270,9 +266,9 @@ func.func @arith_cmpf_false(%arg0: f32, %arg1: f32) -> i1 {
   // CHECK-LABEL: arith_cmpf_false
   // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)
   // CHECK-DAG: [[False:[^ ]*]] = "emitc.constant"() <{value = false}> : () -> i1
-  %ueq = arith.cmpf false, %arg0, %arg1 : f32
+  %false = arith.cmpf false, %arg0, %arg1 : f32
   // CHECK: return [[False]]
-  return %ueq: i1
+  return %false: i1
 }
 
 // -----
@@ -281,13 +277,13 @@ func.func @arith_cmpf_oeq(%arg0: f32, %arg1: f32) -> i1 {
   // CHECK-LABEL: arith_cmpf_oeq
   // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)
   // CHECK-DAG: [[EQ:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NaNArg0]], [[NaNArg1]] : i1, i1
+  // CHECK-DAG: [[NotNaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
+  // CHECK-DAG: [[NotNaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
+  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NotNaNArg0]], [[NotNaNArg1]] : i1, i1
   // CHECK-DAG: [[OEQ:[^ ]*]] = emitc.logical_and [[Ordered]], [[EQ]] : i1, i1
-  %ueq = arith.cmpf oeq, %arg0, %arg1 : f32
+  %oeq = arith.cmpf oeq, %arg0, %arg1 : f32
   // CHECK: return [[OEQ]]
-  return %ueq: i1
+  return %oeq: i1
 }
 
 // -----
@@ -296,9 +292,9 @@ func.func @arith_cmpf_ogt(%arg0: f32, %arg1: f32) -> i1 {
   // CHECK-LABEL: arith_cmpf_ogt
   // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)
   // CHECK-DAG: [[GT:[^ ]*]] = emitc.cmp gt, [[Arg0]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[OrderedArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
-  // CHECK-DAG: [[OrderedArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[OrderedArg0]], [[OrderedArg1]] : i1, i1
+  // CHECK-DAG: [[NotNaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
+  // CHECK-DAG: [[NotNaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
+  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NotNaNArg0]], [[NotNaNArg1]] : i1, i1
   // CHECK-DAG: [[OGT:[^ ]*]] = emitc.logical_and [[Ordered]], [[GT]] : i1, i1
   %ogt = arith.cmpf ogt, %arg0, %arg1 : f32
   // CHECK: return [[OGT]]
@@ -311,13 +307,13 @@ func.func @arith_cmpf_oge(%arg0: f32, %arg1: f32) -> i1 {
   // CHECK-LABEL: arith_cmpf_oge
   // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)
   // CHECK-DAG: [[GE:[^ ]*]] = emitc.cmp ge, [[Arg0]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NaNArg0]], [[NaNArg1]] : i1, i1
+  // CHECK-DAG: [[NotNaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
+  // CHECK-DAG: [[NotNaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
+  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NotNaNArg0]], [[NotNaNArg1]] : i1, i1
   // CHECK-DAG: [[OGE:[^ ]*]] = emitc.logical_and [[Ordered]], [[GE]] : i1, i1
-  %ueq = arith.cmpf oge, %arg0, %arg1 : f32
+  %oge = arith.cmpf oge, %arg0, %arg1 : f32
   // CHECK: return [[OGE]]
-  return %ueq: i1
+  return %oge: i1
 }
 
 // -----
@@ -326,13 +322,13 @@ func.func @arith_cmpf_olt(%arg0: f32, %arg1: f32) -> i1 {
   // CHECK-LABEL: arith_cmpf_olt
   // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)
   // CHECK-DAG: [[LT:[^ ]*]] = emitc.cmp lt, [[Arg0]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NaNArg0]], [[NaNArg1]] : i1, i1
-  // CHECK-DAG: [[UEQ:[^ ]*]] = emitc.logical_and [[Ordered]], [[LT]] : i1, i1
-  %ueq = arith.cmpf olt, %arg0, %arg1 : f32
-  // CHECK: return [[UEQ]]
-  return %ueq: i1
+  // CHECK-DAG: [[NotNaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
+  // CHECK-DAG: [[NotNaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
+  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NotNaNArg0]], [[NotNaNArg1]] : i1, i1
+  // CHECK-DAG: [[OLT:[^ ]*]] = emitc.logical_and [[Ordered]], [[LT]] : i1, i1
+  %olt = arith.cmpf olt, %arg0, %arg1 : f32
+  // CHECK: return [[OLT]]
+  return %olt: i1
 }
 
 // -----
@@ -341,9 +337,9 @@ func.func @arith_cmpf_ole(%arg0: f32, %arg1: f32) -> i1 {
   // CHECK-LABEL: arith_cmpf_ole
   // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)
   // CHECK-DAG: [[LT:[^ ]*]] = emitc.cmp le, [[Arg0]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NaNArg0]], [[NaNArg1]] : i1, i1
+  // CHECK-DAG: [[NotNaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
+  // CHECK-DAG: [[NotNaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
+  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NotNaNArg0]], [[NotNaNArg1]] : i1, i1
   // CHECK-DAG: [[OLE:[^ ]*]] = emitc.logical_and [[Ordered]], [[LT]] : i1, i1
   %ole = arith.cmpf ole, %arg0, %arg1 : f32
   // CHECK: return [[OLE]]
@@ -356,13 +352,13 @@ func.func @arith_cmpf_one(%arg0: f32, %arg1: f32) -> i1 {
   // CHECK-LABEL: arith_cmpf_one
   // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)
   // CHECK-DAG: [[NEQ:[^ ]*]] = emitc.cmp ne, [[Arg0]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NaNArg0]], [[NaNArg1]] : i1, i1
+  // CHECK-DAG: [[NotNaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
+  // CHECK-DAG: [[NotNaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
+  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NotNaNArg0]], [[NotNaNArg1]] : i1, i1
   // CHECK-DAG: [[ONE:[^ ]*]] = emitc.logical_and [[Ordered]], [[NEQ]] : i1, i1
-  %ueq = arith.cmpf one, %arg0, %arg1 : f32
+  %one = arith.cmpf one, %arg0, %arg1 : f32
   // CHECK: return [[ONE]]
-  return %ueq: i1
+  return %one: i1
 }
 
 // -----
@@ -370,12 +366,12 @@ func.func @arith_cmpf_one(%arg0: f32, %arg1: f32) -> i1 {
 func.func @arith_cmpf_ord(%arg0: f32, %arg1: f32) -> i1 {
   // CHECK-LABEL: arith_cmpf_ord
   // CHECK-SAME: ([[Arg0:[^ ]*]]: f32, [[Arg1:[^ ]*]]: f32)
-  // CHECK-DAG: [[NaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
-  // CHECK-DAG: [[NaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
-  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NaNArg0]], [[NaNArg1]] : i1, i1
-  %ueq = arith.cmpf ord, %arg0, %arg1 : f32
+  // CHECK-DAG: [[NotNaNArg0:[^ ]*]] = emitc.cmp eq, [[Arg0]], [[Arg0]] : (f32, f32) -> i1
+  // CHECK-DAG: [[NotNaNArg1:[^ ]*]] = emitc.cmp eq, [[Arg1]], [[Arg1]] : (f32, f32) -> i1
+  // CHECK-DAG: [[Ordered:[^ ]*]] = emitc.logical_and [[NotNaNArg0]], [[NotNaNArg1]] : i1, i1
+  %ord = arith.cmpf ord, %arg0, %arg1 : f32
   // CHECK: return [[Ordered]]
-  return %ueq: i1
+  return %ord: i1
 }
 
 // -----
@@ -551,14 +547,15 @@ func.func @arith_cmpi_index(%arg0: i32, %arg1: i32) -> i1 {
   // CHECK-DAG: [[ULT:[^ ]*]] = emitc.cmp lt, %[[Cst0]], %[[Cst1]] : (!emitc.size_t, !emitc.size_t) -> i1
   %ult = arith.cmpi ult, %idx0, %idx1 : index
 
-  // CHECK-DAG: %[[CastArg0:[^ ]*]] = emitc.cast %[[Cst0]] : !emitc.size_t to !emitc.ssize_t
-  // CHECK-DAG: %[[CastArg1:[^ ]*]] = emitc.cast %[[Cst1]] : !emitc.size_t to !emitc.ssize_t
-  // CHECK-DAG: %[[SLT:[^ ]*]] = emitc.cmp lt, %[[CastArg0]], %[[CastArg1]] : (!emitc.ssize_t, !emitc.ssize_t) -> i1
+  // CHECK-DAG: %[[CastArg0:[^ ]*]] = emitc.cast %[[Cst0]] : !emitc.size_t to !emitc.ptrdiff_t
+  // CHECK-DAG: %[[CastArg1:[^ ]*]] = emitc.cast %[[Cst1]] : !emitc.size_t to !emitc.ptrdiff_t
+  // CHECK-DAG: %[[SLT:[^ ]*]] = emitc.cmp lt, %[[CastArg0]], %[[CastArg1]] : (!emitc.ptrdiff_t, !emitc.ptrdiff_t) -> i1
   %slt = arith.cmpi slt, %idx0, %idx1 : index
 
   // CHECK: return %[[SLT]]
   return %slt: i1
 }
+
 
 // -----
 
@@ -629,6 +626,20 @@ func.func @arith_trunci(%arg0: i32) -> i8 {
 
 // -----
 
+func.func @arith_trunci_to_i1(%arg0: i32) -> i1 {
+  // CHECK-LABEL: arith_trunci_to_i1
+  // CHECK-SAME: (%[[Arg0:[^ ]*]]: i32)
+  // CHECK: %[[Const:.*]] = "emitc.constant"
+  // CHECK-SAME: value = 1
+  // CHECK: %[[And:.*]] = emitc.bitwise_and %[[Arg0]], %[[Const]] : (i32, i32) -> i32
+  // CHECK: emitc.cast %[[And]] : i32 to i1
+  %truncd = arith.trunci %arg0 : i32 to i1
+
+  return %truncd : i1
+}
+
+// -----
+
 func.func @arith_extsi(%arg0: i32) {
   // CHECK-LABEL: arith_extsi
   // CHECK-SAME: ([[Arg0:[^ ]*]]: i32)
@@ -653,14 +664,26 @@ func.func @arith_extui(%arg0: i32) {
 
 // -----
 
+func.func @arith_extui_i1_to_i32(%arg0: i1) {
+  // CHECK-LABEL: arith_extui_i1_to_i32
+  // CHECK-SAME: (%[[Arg0:[^ ]*]]: i1)
+  // CHECK: %[[Conv0:.*]] = emitc.cast %[[Arg0]] : i1 to ui1
+  // CHECK: %[[Conv1:.*]] = emitc.cast %[[Conv0]] : ui1 to ui32
+  // CHECK: emitc.cast %[[Conv1]] : ui32 to i32
+  %idx = arith.extui %arg0 : i1 to i32
+  return
+}
+
+// -----
+
 func.func @arith_index_cast(%arg0: i32) -> i32 {
   // CHECK-LABEL: arith_index_cast
   // CHECK-SAME: (%[[Arg0:[^ ]*]]: i32)
-  // CHECK: %[[Conv0:.*]] = emitc.cast %[[Arg0]] : i32 to !emitc.ssize_t
-  // CHECK: %[[Conv1:.*]] = emitc.cast %[[Conv0]] : !emitc.ssize_t to !emitc.size_t
+  // CHECK: %[[Conv0:.*]] = emitc.cast %[[Arg0]] : i32 to !emitc.ptrdiff_t
+  // CHECK: %[[Conv1:.*]] = emitc.cast %[[Conv0]] : !emitc.ptrdiff_t to !emitc.size_t
   %idx = arith.index_cast %arg0 : i32 to index
-  // CHECK: %[[Conv2:.*]] = emitc.cast %[[Conv1]] : !emitc.size_t to !emitc.ssize_t
-  // CHECK: %[[Conv3:.*]] = emitc.cast %[[Conv2]] : !emitc.ssize_t to i32
+  // CHECK: %[[Conv2:.*]] = emitc.cast %[[Conv1]] : !emitc.size_t to !emitc.ptrdiff_t
+  // CHECK: %[[Conv3:.*]] = emitc.cast %[[Conv2]] : !emitc.ptrdiff_t to i32
   %int = arith.index_cast %idx : index to i32
 
   // CHECK: %[[Const:.*]] = "emitc.constant"
@@ -693,22 +716,4 @@ func.func @arith_index_castui(%arg0: i32) -> i32 {
   %bool = arith.index_castui %idx : index to i1
 
   return %int : i32
-}
-
-// -----
-
-func.func @arith_divui_remui(%arg0: i32, %arg1: i32) -> i32 {
-  // CHECK-LABEL: arith_divui_remui
-  // CHECK-SAME: (%[[Arg0:[^ ]*]]: i32, %[[Arg1:[^ ]*]]: i32)
-  // CHECK: %[[Conv0:.*]] = emitc.cast %[[Arg0]] : i32 to ui32
-  // CHECK: %[[Conv1:.*]] = emitc.cast %[[Arg1]] : i32 to ui32
-  // CHECK: %[[Div:.*]] = emitc.div %[[Conv0]], %[[Conv1]] : (ui32, ui32) -> ui32
-  %div = arith.divui %arg0, %arg1 : i32
-
-  // CHECK: %[[Conv2:.*]] = emitc.cast %[[Arg0]] : i32 to ui32
-  // CHECK: %[[Conv3:.*]] = emitc.cast %[[Arg1]] : i32 to ui32
-  // CHECK: %[[Rem:.*]] = emitc.rem %[[Conv2]], %[[Conv3]] : (ui32, ui32) -> ui32
-  %rem = arith.remui %arg0, %arg1 : i32
-
-  return %div : i32
 }

--- a/mlir/test/Dialect/EmitC/invalid_ops.mlir
+++ b/mlir/test/Dialect/EmitC/invalid_ops.mlir
@@ -170,7 +170,7 @@ func.func @add_float_pointer(%arg0: f32, %arg1: !emitc.ptr<f32>) {
 // -----
 
 func.func @div_tensor(%arg0: tensor<i32>, %arg1: tensor<i32>) {
-    // expected-error @+1 {{'emitc.div' op operand #0 must be floating-point type supported by EmitC or integer type supported by EmitC or index or EmitC signed size type or EmitC unsigned size type or EmitC opaque type, but got 'tensor<i32>'}}
+    // expected-error @+1 {{'emitc.div' op operand #0 must be floating-point type supported by EmitC or integer, index or opaque type supported by EmitC, but got 'tensor<i32>'}}
     %1 = "emitc.div" (%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     return
 }
@@ -178,7 +178,7 @@ func.func @div_tensor(%arg0: tensor<i32>, %arg1: tensor<i32>) {
 // -----
 
 func.func @mul_tensor(%arg0: tensor<i32>, %arg1: tensor<i32>) {
-    // expected-error @+1 {{'emitc.mul' op operand #0 must be floating-point type supported by EmitC or integer type supported by EmitC or index or EmitC signed size type or EmitC unsigned size type or EmitC opaque type, but got 'tensor<i32>'}}
+    // expected-error @+1 {{'emitc.mul' op operand #0 must be floating-point type supported by EmitC or integer, index or opaque type supported by EmitC, but got 'tensor<i32>'}}
     %1 = "emitc.mul" (%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     return
 }
@@ -186,7 +186,7 @@ func.func @mul_tensor(%arg0: tensor<i32>, %arg1: tensor<i32>) {
 // -----
 
 func.func @rem_tensor(%arg0: tensor<i32>, %arg1: tensor<i32>) {
-    // expected-error @+1 {{'emitc.rem' op operand #0 must be integer type supported by EmitC or index or EmitC signed size type or EmitC unsigned size type or EmitC opaque type, but got 'tensor<i32>'}}
+    // expected-error @+1 {{'emitc.rem' op operand #0 must be integer, index or opaque type supported by EmitC, but got 'tensor<i32>'}}
     %1 = "emitc.rem" (%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     return
 }
@@ -194,7 +194,7 @@ func.func @rem_tensor(%arg0: tensor<i32>, %arg1: tensor<i32>) {
 // -----
 
 func.func @rem_float(%arg0: f32, %arg1: f32) {
-    // expected-error @+1 {{'emitc.rem' op operand #0 must be integer type supported by EmitC or index or EmitC signed size type or EmitC unsigned size type or EmitC opaque type, but got 'f32'}}
+    // expected-error @+1 {{'emitc.rem' op operand #0 must be integer, index or opaque type supported by EmitC, but got 'f32'}}
     %1 = "emitc.rem" (%arg0, %arg1) : (f32, f32) -> f32
     return
 }

--- a/mlir/test/Dialect/EmitC/invalid_types.mlir
+++ b/mlir/test/Dialect/EmitC/invalid_types.mlir
@@ -85,7 +85,7 @@ func.func @illegal_array_with_tensor_element_type(
 // -----
 
 func.func @illegal_integer_type(%arg0: i11, %arg1: i11) -> i11 {
-    // expected-error @+1 {{'emitc.mul' op operand #0 must be floating-point type supported by EmitC or integer type supported by EmitC or index or EmitC signed size type or EmitC unsigned size type or EmitC opaque type, but got 'i11'}}
+    // expected-error @+1 {{'emitc.mul' op operand #0 must be floating-point type supported by EmitC or integer, index or opaque type supported by EmitC, but got 'i11'}}
     %mul = "emitc.mul" (%arg0, %arg1) : (i11, i11) -> i11
     return
 }
@@ -93,7 +93,7 @@ func.func @illegal_integer_type(%arg0: i11, %arg1: i11) -> i11 {
 // -----
 
 func.func @illegal_float_type(%arg0: f80, %arg1: f80) {
-    // expected-error @+1 {{'emitc.mul' op operand #0 must be floating-point type supported by EmitC or integer type supported by EmitC or index or EmitC signed size type or EmitC unsigned size type or EmitC opaque type, but got 'f80'}}
+    // expected-error @+1 {{'emitc.mul' op operand #0 must be floating-point type supported by EmitC or integer, index or opaque type supported by EmitC, but got 'f80'}}
     %mul = "emitc.mul" (%arg0, %arg1) : (f80, f80) -> f80
     return
 }

--- a/mlir/test/Dialect/EmitC/ops.mlir
+++ b/mlir/test/Dialect/EmitC/ops.mlir
@@ -41,6 +41,9 @@ func.func @cast(%arg0: i32) {
 
 func.func @c() {
   %1 = "emitc.constant"(){value = 42 : i32} : () -> i32
+  %2 = "emitc.constant"(){value = 42 : index} : () -> !emitc.size_t
+  %3 = "emitc.constant"(){value = 42 : index} : () -> !emitc.ssize_t
+  %4 = "emitc.constant"(){value = 42 : index} : () -> !emitc.ptrdiff_t
   return
 }
 

--- a/mlir/test/Dialect/EmitC/types.mlir
+++ b/mlir/test/Dialect/EmitC/types.mlir
@@ -11,7 +11,13 @@ func.func @array_types(
   // CHECK-SAME: !emitc.array<30x!emitc.ptr<i32>>,
   %arg2: !emitc.array<30x!emitc.ptr<i32>>,
   // CHECK-SAME: !emitc.array<30x!emitc.opaque<"int">>
-  %arg3: !emitc.array<30x!emitc.opaque<"int">>
+  %arg3: !emitc.array<30x!emitc.opaque<"int">>,
+  // CHECK-SAME: !emitc.array<30x!emitc.size_t>
+  %arg4: !emitc.array<30x!emitc.size_t>,
+  // CHECK-SAME: !emitc.array<30x!emitc.ssize_t>
+  %arg5: !emitc.array<30x!emitc.ssize_t>,
+  // CHECK-SAME: !emitc.array<30x!emitc.ptrdiff_t>
+  %arg6: !emitc.array<30x!emitc.ptrdiff_t>
 ) {
   return
 }
@@ -54,12 +60,14 @@ func.func @pointer_types() {
   return
 }
 
-// CHECK-LABEL: func @index_types() 
-func.func @index_types() {
+// CHECK-LABEL: func @size_types() 
+func.func @size_types() {
   // CHECK-NEXT: !emitc.ssize_t
   emitc.call_opaque "f"() {template_args = [!emitc.ssize_t]} : () -> ()
   // CHECK-NEXT: !emitc.size_t
   emitc.call_opaque "f"() {template_args = [!emitc.size_t]} : () -> ()
+  // CHECK-NEXT: !emitc.ptrdiff_t
+  emitc.call_opaque "f"() {template_args = [!emitc.ptrdiff_t]} : () -> ()
 
   return
 }

--- a/mlir/test/Target/Cpp/types.mlir
+++ b/mlir/test/Target/Cpp/types.mlir
@@ -42,6 +42,8 @@ func.func @size_types() {
   emitc.call_opaque "f"() {template_args = [!emitc.ssize_t]} : () -> ()
   // CHECK-NEXT: f<size_t>();
   emitc.call_opaque "f"() {template_args = [!emitc.size_t]} : () -> ()
+  // CHECK-NEXT: f<ptrdiff_t>();
+  emitc.call_opaque "f"() {template_args = [!emitc.ptrdiff_t]} : () -> ()
 
   return
 }


### PR DESCRIPTION
When upstreaming our fork's changes to the main LLVM, we had to introduce minor changes to the code that weren't backported into our fork. This commit does this backport to make bumping easier.