### PR TITLE
[FXML-4642] Lower extf, truncf to EmitC

### DIFF
--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -119,6 +119,7 @@ bool mlir::emitc::isSupportedFloatType(Type type) {
   if (auto floatType = llvm::dyn_cast<FloatType>(type)) {
     switch (floatType.getWidth()) {
     case 32:
+      return !isa<FloatTF32Type>(floatType);
     case 64:
       return true;
     default:

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-unsupported.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-unsupported.mlir
@@ -134,3 +134,116 @@ func.func @arith_remui_vector(%arg0: vector<5xi32>, %arg1: vector<5xi32>) -> vec
   %divui = arith.remui %arg0, %arg1 : vector<5xi32>
   return %divui: vector<5xi32>
 }
+
+// -----
+
+func.func @arith_extf_to_bf16(%arg0: f8E4M3FN) {
+  // expected-error @+1 {{failed to legalize operation 'arith.extf'}}
+  %ext = arith.extf %arg0 : f8E4M3FN to bf16
+  return
+}
+
+// -----
+
+func.func @arith_extf_to_f16(%arg0: f8E4M3FN) {
+  // expected-error @+1 {{failed to legalize operation 'arith.extf'}}
+  %ext = arith.extf %arg0 : f8E4M3FN to f16
+  return
+}
+
+
+// -----
+
+func.func @arith_extf_to_tf32(%arg0: f8E4M3FN) {
+  // expected-error @+1 {{failed to legalize operation 'arith.extf'}}
+  %ext = arith.extf %arg0 : f8E4M3FN to tf32
+  return
+}
+
+// -----
+
+func.func @arith_extf_to_float80(%arg0: f8E4M3FN) {
+  // expected-error @+1 {{failed to legalize operation 'arith.extf'}}
+  %ext = arith.extf %arg0 : f8E4M3FN to f80
+  return
+}
+
+// -----
+
+func.func @arith_extf_to_float128(%arg0: f8E4M3FN) {
+  // expected-error @+1 {{failed to legalize operation 'arith.extf'}}
+  %ext = arith.extf %arg0 : f8E4M3FN to f128
+  return
+}
+
+// -----
+
+func.func @arith_truncf_to_f80(%arg0: f128) {
+  // expected-error @+1 {{failed to legalize operation 'arith.truncf'}}
+  %trunc = arith.truncf %arg0 : f128 to f80
+  return
+}
+
+// -----
+
+func.func @arith_truncf_to_tf32(%arg0: f64) {
+  // expected-error @+1 {{failed to legalize operation 'arith.truncf'}}
+  %trunc = arith.truncf %arg0 : f64 to tf32
+  return
+}
+
+// -----
+
+func.func @arith_truncf_to_f16(%arg0: f64) {
+  // expected-error @+1 {{failed to legalize operation 'arith.truncf'}}
+  %trunc = arith.truncf %arg0 : f64 to f16
+  return
+}
+
+// -----
+
+func.func @arith_truncf_to_bf16(%arg0: f64) {
+  // expected-error @+1 {{failed to legalize operation 'arith.truncf'}}
+  %trunc = arith.truncf %arg0 : f64 to bf16
+  return
+}
+
+// -----
+
+func.func @arith_truncf_to_f8E4M3FN(%arg0: f64) {
+  // expected-error @+1 {{failed to legalize operation 'arith.truncf'}}
+  %trunc = arith.truncf %arg0 : f64 to f8E4M3FN
+  return
+}
+
+// -----
+
+func.func @arith_truncf_to_f8E5M2(%arg0: f64) {
+  // expected-error @+1 {{failed to legalize operation 'arith.truncf'}}
+  %trunc = arith.truncf %arg0 : f64 to f8E5M2
+  return
+}
+
+// -----
+
+func.func @arith_truncf_to_f8E4M3FNUZ(%arg0: f64) {
+  // expected-error @+1 {{failed to legalize operation 'arith.truncf'}}
+  %trunc = arith.truncf %arg0 : f64 to f8E4M3FNUZ
+  return
+}
+
+// -----
+
+func.func @arith_truncf_to_f8E4M3FN(%arg0: f64) {
+  // expected-error @+1 {{failed to legalize operation 'arith.truncf'}}
+  %trunc = arith.truncf %arg0 : f64 to f8E4M3FN
+  return
+}
+
+// -----
+
+func.func @arith_truncf_to_f8E4M3B11FNUZ(%arg0: f64) {
+  // expected-error @+1 {{failed to legalize operation 'arith.truncf'}}
+  %trunc = arith.truncf %arg0 : f64 to f8E4M3B11FNUZ
+  return
+}

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -712,3 +712,18 @@ func.func @arith_divui_remui(%arg0: i32, %arg1: i32) -> i32 {
 
   return %div : i32
 }
+
+// -----
+
+func.func @arith_extf_truncf(%arg0: f32, %arg1: f64) {
+  // CHECK-LABEL: arith_extf_truncf
+  // CHECK-SAME: (%[[Arg0:[^ ]*]]: f32, %[[Arg1:[^ ]*]]: f64)
+
+  // CHECK: %[[Conv1:.*]] = emitc.cast %[[Arg0]] : f32 to f64
+  %ext = arith.extf %arg0 : f32 to f64
+
+  // CHECK: %[[Conv2:.*]] = emitc.cast %[[Arg1]] : f64 to f32
+  %trunc = arith.truncf %arg1 : f64 to f32
+
+  return
+}


### PR DESCRIPTION
... and throughout the course of this lowering, I figured that TF32 wasn't excluded from EmitC types -- although we never specifically handle it AFAIK. This commit therefore also excludes TF32 from valid EmitC types.