### PR TITLE
[FXML-4819] Lower tosa.cast uiX -> (us)?iY to extui

### DIFF
--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
@@ -615,8 +615,7 @@ static Value createLinalgBodyCalculationForElementwiseOp(
     }
 
     if (isa<IntegerType>(srcTy) && isa<IntegerType>(dstTy) && bitExtend) {
-      auto srcIntTy = dyn_cast<IntegerType>(srcTy);
-      if (srcIntTy.isUnsigned())
+      if (cast<IntegerType>(srcTy).isUnsigned())
         return rewriter.create<arith::ExtUIOp>(loc, resultTypes, args,
                                                std::nullopt);
       return rewriter.create<arith::ExtSIOp>(loc, resultTypes, args,

--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalg.cpp
@@ -614,9 +614,14 @@ static Value createLinalgBodyCalculationForElementwiseOp(
                                             args.front(), zero);
     }
 
-    if (isa<IntegerType>(srcTy) && isa<IntegerType>(dstTy) && bitExtend)
+    if (isa<IntegerType>(srcTy) && isa<IntegerType>(dstTy) && bitExtend) {
+      auto srcIntTy = dyn_cast<IntegerType>(srcTy);
+      if (srcIntTy.isUnsigned())
+        return rewriter.create<arith::ExtUIOp>(loc, resultTypes, args,
+                                               std::nullopt);
       return rewriter.create<arith::ExtSIOp>(loc, resultTypes, args,
                                              std::nullopt);
+    }
 
     if (isa<IntegerType>(srcTy) && isa<IntegerType>(dstTy) && !bitExtend) {
       return rewriter.create<arith::TruncIOp>(loc, dstTy, args[0]);

--- a/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg.mlir
+++ b/mlir/test/Conversion/TosaToLinalg/tosa-to-linalg.mlir
@@ -636,6 +636,11 @@ func.func @test_simple_i16(%arg0: tensor<1xi16>) -> () {
 func.func @test_simple_ui8(%arg0: tensor<1xui8>) -> () {
   // CHECK: arith.uitofp
   %0 = tosa.cast %arg0 : (tensor<1xui8>) -> tensor<1xf32>
+
+  // CHECK: linalg.generic
+  // CHECK: arith.extui {{%.+}} : i8 to i32
+  %1 = tosa.cast %arg0 : (tensor<1xui8>) -> tensor<1xi32>
+
   return
 }
 
@@ -797,8 +802,8 @@ func.func @test_simple_i32(%arg0: tensor<1xi32>, %arg1: tensor<1xui32>) -> () {
 
 // -----
 
-// CHECK-LABEL: @test_simple_ui8
-func.func @test_simple_ui8(%arg0: tensor<1xi8>) -> () {
+// CHECK-LABEL: @test_simple_i8
+func.func @test_simple_i8(%arg0: tensor<1xi8>) -> () {
 
   // CHECK: linalg.generic
   // CHECK: sitofp


### PR DESCRIPTION
TOSA Cast ops accept unsigned integers as input; when widening such types, they must not be sign-extended.

This commit also fixes the naming of one test that appeared to be wrong (the test uses i8 instead of ui8).