### PR TITLE
PDLL: Add equals operator

### DIFF
--- a/mlir/include/mlir/Dialect/PDL/IR/Builtins.h
+++ b/mlir/include/mlir/Dialect/PDL/IR/Builtins.h
@@ -65,6 +65,7 @@ LogicalResult exp2(PatternRewriter &rewriter, PDLResultList &results,
                    llvm::ArrayRef<PDLValue> args);
 LogicalResult abs(PatternRewriter &rewriter, PDLResultList &results,
                   llvm::ArrayRef<PDLValue> args);
+LogicalResult equals(PatternRewriter &rewriter, Attribute lhs, Attribute rhs);
 } // namespace builtin
 } // namespace pdl
 } // namespace mlir

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
@@ -230,6 +230,10 @@ Token Lexer::lexToken() {
         ++curPtr;
         return formToken(Token::equal_arrow, tokStart);
       }
+      if (*curPtr == '=') {
+        ++curPtr;
+        return formToken(Token::equal_equal, tokStart);
+      }
       return formToken(Token::equal, tokStart);
     case ';':
       return formToken(Token::semicolon, tokStart);

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.h
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.h
@@ -80,6 +80,7 @@ public:
     dot,
     equal,
     equal_arrow,
+    equal_equal,
     semicolon,
 
     /// Arithmetic.

--- a/mlir/lib/Tools/mlir-pdll-lsp-server/PDLLServer.cpp
+++ b/mlir/lib/Tools/mlir-pdll-lsp-server/PDLLServer.cpp
@@ -810,6 +810,8 @@ public:
     while (scope) {
       for (const ast::Decl *decl : scope->getDecls()) {
         if (const auto *cst = dyn_cast<ast::UserConstraintDecl>(decl)) {
+          if (cst->getName().getName().starts_with("__builtin"))
+            continue;
           lsp::CompletionItem item;
           item.label = cst->getName().getName().str();
           item.kind = lsp::CompletionItemKind::Interface;

--- a/mlir/test/lib/Tools/PDLL/TestPDLL.pdll
+++ b/mlir/test/lib/Tools/PDLL/TestPDLL.pdll
@@ -14,3 +14,10 @@ Pattern TestSimplePattern => replace op<test.simple> with op<test.success>;
 
 // Test the import of interfaces.
 Pattern TestInterface => replace _: CastOpInterface with op<test.success>;
+
+// Test equals builtin
+Pattern TestEquals {
+    let op = op<test.equals> {val = val : Attr};
+    val == attr<"4 : i32">;
+    replace op with op<test.success>;
+}

--- a/mlir/test/mlir-pdll-lsp-server/completion.test
+++ b/mlir/test/mlir-pdll-lsp-server/completion.test
@@ -196,24 +196,6 @@
 // CHECK-NEXT:        "kind": 8,
 // CHECK-NEXT:        "label": "ValueCst",
 // CHECK-NEXT:        "sortText": "2_ValueCst"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "detail": "(Attr: Attr) -> Attr",
-// CHECK-NEXT:        "kind": 8,
-// CHECK-NEXT:        "label": "__builtin_exp2Constraint",
-// CHECK-NEXT:        "sortText": "2___builtin_exp2Constraint"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "detail": "(Attr: Attr) -> Attr",
-// CHECK-NEXT:        "kind": 8,
-// CHECK-NEXT:        "label": "__builtin_log2Constraint",
-// CHECK-NEXT:        "sortText": "2___builtin_log2Constraint"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "detail": "(Attr: Attr) -> Attr",
-// CHECK-NEXT:        "kind": 8,
-// CHECK-NEXT:        "label": "__builtin_absConstraint",
-// CHECK-NEXT:        "sortText": "2___builtin_absConstraint"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ]
 // CHECK-NEXT:  }

--- a/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
+++ b/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
@@ -356,3 +356,17 @@ Pattern TestOperatorsInRewriteSection {
   };
 }
 
+
+// -----
+// CHECK-LABEL:   pdl.pattern @TestEquals : benefit(0) {
+// CHECK:           %[[VAL_0:.*]] = operands
+// CHECK:           %[[VAL_1:.*]] = attribute
+// CHECK:           %[[VAL_2:.*]] = types
+// CHECK:           %[[VAL_3:.*]] = operation "test.op"(%[[VAL_0]] : !pdl.range<value>)  {"val" = %[[VAL_1]]} -> (%[[VAL_2]] : !pdl.range<type>)
+// CHECK:           %[[VAL_4:.*]] = attribute = 4 : i32
+// CHECK:           apply_native_constraint "__builtin_equals"(%[[VAL_1]], %[[VAL_4]] : !pdl.attribute, !pdl.attribute)
+Pattern TestEquals {
+    let op = op<test.op> {val = val : Attr};
+    val == attr<"4 : i32">;
+    replace op with op<test.success>;
+}

--- a/mlir/test/mlir-pdll/Integration/test-pdll.mlir
+++ b/mlir/test/mlir-pdll/Integration/test-pdll.mlir
@@ -15,3 +15,12 @@ func.func @testImportedInterface() -> i1 {
   %value = "builtin.unrealized_conversion_cast"() : () -> (i1)
   return %value : i1
 }
+
+// CHECK-LABEL: func @test_builtin
+func.func @test_builtin() {
+  // CHECK: test.success
+  // CHECK: test.equals_neg
+  "test.equals"() { val = 4 : i32 }: () -> ()
+  "test.equals_neg"() { val = 4 : i32 }: () -> ()
+  return
+}

--- a/mlir/test/mlir-pdll/Parser/expr-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr-failure.pdll
@@ -628,3 +628,19 @@ Pattern {
     erase root;
   };
 }
+
+// -----
+
+Pattern {
+  // CHECK: expected expression
+  ==
+  erase _: Op;
+}
+
+// -----
+
+Pattern {
+  // CHECK: expected expression
+  attr<"4 : i32"> ==
+  erase _: Op;
+}

--- a/mlir/test/mlir-pdll/Parser/expr.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr.pdll
@@ -631,3 +631,14 @@ Pattern {
   let x : Attr = a + b * c;
   erase _: Op;
 }
+
+// -----
+// CHECK: Module {{.*}}
+// CHECK: UserConstraintDecl {{.*}} Name<__builtin_equals> ResultType<Tuple<>>
+// CHECK: UserConstraintDecl {{.*}} Name<__builtin_equals> ResultType<Tuple<>>
+Pattern {
+  attr<"4 : i32"> == attr<"5 : i32">;
+  let a: Attr;
+  a == a;
+  erase _: Op;
+}

--- a/mlir/unittests/Dialect/PDL/BuiltinTest.cpp
+++ b/mlir/unittests/Dialect/PDL/BuiltinTest.cpp
@@ -793,4 +793,24 @@ TEST_F(BuiltinTest, abs) {
         1.0);
   }
 }
+
+TEST_F(BuiltinTest, equals) {
+  auto onei16 = rewriter.getI16IntegerAttr(1);
+  auto onei32 = rewriter.getI32IntegerAttr(1);
+  auto zeroi32 = rewriter.getI32IntegerAttr(0);
+
+  EXPECT_TRUE(builtin::equals(rewriter, onei16, onei16).succeeded());
+  EXPECT_TRUE(builtin::equals(rewriter, onei16, onei32).failed());
+  EXPECT_TRUE(builtin::equals(rewriter, zeroi32, onei32).failed());
+
+  auto onef32 = rewriter.getF32FloatAttr(1.0);
+  auto zerof32 = rewriter.getF32FloatAttr(0.0);
+  auto negzerof32 = rewriter.getF32FloatAttr(-0.0);
+  auto zerof64 = rewriter.getF64FloatAttr(0.0);
+
+  EXPECT_TRUE(builtin::equals(rewriter, onef32, onef32).succeeded());
+  EXPECT_TRUE(builtin::equals(rewriter, onef32, zerof32).failed());
+  EXPECT_TRUE(builtin::equals(rewriter, negzerof32, zerof32).succeeded());
+  EXPECT_TRUE(builtin::equals(rewriter, zerof32, zerof64).failed());
+}
 } // namespace


### PR DESCRIPTION
Allows to write
```
Pattern TestEquals {
    let op = op<test.op> {val = val : Attr};
    val == attr<"4 : i32">;
    replace op with op<test.success>;
}
```.
In addition, this PR has a commit to exclude __builtins from code completion in LSP.