### PR TITLE
PDLL: Create array/dict attributes more directly

### DIFF
--- a/mlir/include/mlir/Dialect/PDL/IR/Builtins.h
+++ b/mlir/include/mlir/Dialect/PDL/IR/Builtins.h
@@ -40,13 +40,9 @@ enum class UnaryOpKind {
   log2,
 };
 
-LogicalResult createDictionaryAttr(PatternRewriter &rewriter,
-                                   PDLResultList &results,
-                                   ArrayRef<PDLValue> args);
 LogicalResult addEntryToDictionaryAttr(PatternRewriter &rewriter,
                                        PDLResultList &results,
                                        ArrayRef<PDLValue> args);
-Attribute createArrayAttr(PatternRewriter &rewriter);
 Attribute addElemToArrayAttr(PatternRewriter &rewriter, Attribute attr,
                              Attribute element);
 LogicalResult mul(PatternRewriter &rewriter, PDLResultList &results,

--- a/mlir/lib/Dialect/PDL/IR/Builtins.cpp
+++ b/mlir/lib/Dialect/PDL/IR/Builtins.cpp
@@ -19,13 +19,6 @@ using namespace mlir;
 namespace mlir::pdl {
 namespace builtin {
 
-LogicalResult createDictionaryAttr(PatternRewriter &rewriter,
-                                   PDLResultList &results,
-                                   ArrayRef<PDLValue> args) {
-  results.push_back(rewriter.getDictionaryAttr({}));
-  return success();
-}
-
 LogicalResult addEntryToDictionaryAttr(PatternRewriter &rewriter,
                                        PDLResultList &results,
                                        ArrayRef<PDLValue> args) {
@@ -43,10 +36,6 @@ LogicalResult addEntryToDictionaryAttr(PatternRewriter &rewriter,
   values.push_back(rewriter.getNamedAttr(name, attrEntry));
   results.push_back(rewriter.getDictionaryAttr(values));
   return success();
-}
-
-mlir::Attribute createArrayAttr(mlir::PatternRewriter &rewriter) {
-  return rewriter.getArrayAttr({});
 }
 
 mlir::Attribute addElemToArrayAttr(mlir::PatternRewriter &rewriter,
@@ -352,16 +341,10 @@ LogicalResult equals(mlir::PatternRewriter &, mlir::Attribute lhs,
 void registerBuiltins(PDLPatternModule &pdlPattern) {
   using namespace builtin;
   // See Parser::defineBuiltins()
-  pdlPattern.registerRewriteFunction("__builtin_createDictionaryAttr_rewrite",
-                                     createDictionaryAttr);
   pdlPattern.registerRewriteFunction(
       "__builtin_addEntryToDictionaryAttr_rewrite", addEntryToDictionaryAttr);
-  pdlPattern.registerRewriteFunction("__builtin_createArrayAttr",
-                                     createArrayAttr);
   pdlPattern.registerRewriteFunction("__builtin_addElemToArrayAttr",
                                      addElemToArrayAttr);
-  pdlPattern.registerConstraintFunctionWithResults(
-      "__builtin_createDictionaryAttr_constraint", createDictionaryAttr);
   pdlPattern.registerConstraintFunctionWithResults(
       "__builtin_addEntryToDictionaryAttr_constraint",
       addEntryToDictionaryAttr);

--- a/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
+++ b/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
@@ -167,7 +167,7 @@ Pattern TypeExpr => erase op<> -> (type<"i32">);
 // CHECK:           %[[VAL_1:.*]] = operation "test.op"
 // CHECK:           %[[VAL_2:.*]] = attribute = "test"
 // CHECK:           rewrite %[[VAL_1]] {
-// CHECK:             %[[VAL_3:.*]] = apply_native_rewrite "__builtin_createDictionaryAttr_rewrite"
+// CHECK:             %[[VAL_3:.*]] = attribute = {}
 // CHECK:             %[[VAL_4:.*]] = attribute = "firstAttr"
 // CHECK:             %[[VAL_5:.*]] = apply_native_rewrite "__builtin_addEntryToDictionaryAttr_rewrite"(%[[VAL_3]], %[[VAL_4]], %[[VAL_2]]
 // CHECK:             %[[VAL_6:.*]] = operation "test.success"  {"some_dictionary" = %[[VAL_5]]}
@@ -188,7 +188,7 @@ Pattern RewriteOneEntryDictionary {
 // CHECK:           %[[VAL_2:.*]] = attribute = "test2"
 // CHECK:           %[[VAL_3:.*]] = attribute = "test3"
 // CHECK:           rewrite %[[VAL_1]] {
-// CHECK:             %[[VAL_4:.*]] = apply_native_rewrite "__builtin_createDictionaryAttr_rewrite"
+// CHECK:             %[[VAL_4:.*]] = attribute = {}
 // CHECK:             %[[VAL_5:.*]] = attribute = "firstAttr"
 // CHECK:             %[[VAL_6:.*]] = attribute = "test1"
 // CHECK:             %[[VAL_7:.*]] = apply_native_rewrite "__builtin_addEntryToDictionaryAttr_rewrite"(%[[VAL_4]], %[[VAL_5]], %[[VAL_6]]
@@ -213,8 +213,8 @@ Pattern RewriteMultipleEntriesDictionary {
 // CHECK-LABEL:   pdl.pattern @RewriteOneDictionaryArrayAttr
 // CHECK:           %[[VAL_1:.*]] = operation "test.op"
 // CHECK:           rewrite %[[VAL_1]] {
-// CHECK:             %[[VAL_2:.*]] = apply_native_rewrite "__builtin_createArrayAttr"
-// CHECK:             %[[VAL_3:.*]] = apply_native_rewrite "__builtin_createDictionaryAttr_rewrite"
+// CHECK:             %[[VAL_2:.*]] = attribute = []
+// CHECK:             %[[VAL_3:.*]] = attribute = {}
 // CHECK:             %[[VAL_4:.*]] = attribute = "firstAttr"
 // CHECK:             %[[VAL_5:.*]] = attribute = "test1"
 // CHECK:             %[[VAL_6:.*]] = apply_native_rewrite "__builtin_addEntryToDictionaryAttr_rewrite"(%[[VAL_3]], %[[VAL_4]], %[[VAL_5]]
@@ -235,8 +235,8 @@ Pattern RewriteOneDictionaryArrayAttr {
 // CHECK:           %[[VAL_1:.*]] = operation "test.op"
 // CHECK:           %[[VAL_2:.*]] = attribute = "test2"
 // CHECK:           rewrite %[[VAL_1]] {
-// CHECK:             %[[VAL_3:.*]] = apply_native_rewrite "__builtin_createArrayAttr"
-// CHECK:             %[[VAL_4:.*]] = apply_native_rewrite "__builtin_createDictionaryAttr_rewrite"
+// CHECK:             %[[VAL_3:.*]] = attribute = []
+// CHECK:             %[[VAL_4:.*]] = attribute = {}
 // CHECK:             %[[VAL_5:.*]] = attribute = "firstAttr"
 // CHECK:             %[[VAL_6:.*]] = attribute = "test1"
 // CHECK:             %[[VAL_7:.*]] = apply_native_rewrite "__builtin_addEntryToDictionaryAttr_rewrite"(%[[VAL_4]], %[[VAL_5]], %[[VAL_6]]

--- a/mlir/test/mlir-pdll/Parser/expr.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr.pdll
@@ -32,16 +32,16 @@ Pattern {
 
 // -----
 
+// CHECK-LABEL: Module
 // CHECK: |-NamedAttributeDecl {{.*}}  Name<some_array>
 // CHECK: `-UserRewriteDecl {{.*}} Name<__builtin_addElemToArrayAttr> ResultType<Attr>
 // CHECK:   `Arguments`
 // CHECK:     CallExpr {{.*}} Type<Attr>
-// CHECK:       UserRewriteDecl {{.*}} Name<__builtin_createArrayAttr> ResultType<Attr>
+// CHECK:       AttributeExpr {{.*}} Value<"[]">
 // CHECK:     CallExpr {{.*}} Type<Attr>
 // CHECK:       UserRewriteDecl {{.*}} Name<__builtin_addEntryToDictionaryAttr_rewrite> ResultType<Attr>
 // CHECK:         `Arguments`
-// CHECK:           CallExpr {{.*}} Type<Attr>
-// CHECK:             UserRewriteDecl {{.*}} Name<__builtin_createDictionaryAttr_rewrite> ResultType<Attr>
+// CHECK:             AttributeExpr {{.*}} Value<"{}">
 // CHECK:             AttributeExpr {{.*}} Value<""firstAttr"">
 
 Pattern {
@@ -55,15 +55,10 @@ Pattern {
 
 // -----
 
+// CHECK-LABEL: Module
 //     CHECK:LetStmt {{.*}}
 //CHECK-NEXT:`-VariableDecl {{.*}} Name<dictionary> Type<Attr>
-//CHECK-NEXT:  `-CallExpr {{.*}} Type<Attr>
-//CHECK-NEXT:    `-DeclRefExpr {{.*}} Type<Constraint>
-//CHECK-NEXT:      `-UserConstraintDecl {{.*}} Name<__builtin_createDictionaryAttr_constraint> ResultType<Attr>
-//CHECK-NEXT:        `Results`
-//CHECK-NEXT:          `-VariableDecl {{.*}} Name<> Type<Attr>
-//CHECK-NEXT:            `Constraints`
-//CHECK-NEXT:              `-AttrConstraintDecl {{.*}}
+//CHECK-NEXT:  `-AttributeExpr {{.*}} Value<"{}">
 //CHECK-NEXT:ReturnStmt {{.*}}
 
 Constraint getEmptyDict() -> Attr {
@@ -73,19 +68,14 @@ Constraint getEmptyDict() -> Attr {
 
 // -----
 
+// CHECK-LABEL: Module
 //     CHECK:LetStmt {{.*}}
 //CHECK-NEXT:`-VariableDecl {{.*}} Name<dictionary> Type<Attr>
 //CHECK-NEXT:  `-CallExpr {{.*}} Type<Attr>
 //CHECK-NEXT:    `-DeclRefExpr {{.*}} Type<Constraint>
 //CHECK-NEXT:      `-UserConstraintDecl {{.*}} Name<__builtin_addEntryToDictionaryAttr_constraint> ResultType<Attr>
 //     CHECK:    `Arguments`
-//CHECK-NEXT:      |-CallExpr {{.*}} Type<Attr>
-//CHECK-NEXT:      | `-DeclRefExpr {{.*}} Type<Constraint>
-//CHECK-NEXT:      |   `-UserConstraintDecl {{.*}} Name<__builtin_createDictionaryAttr_constraint> ResultType<Attr>
-//CHECK-NEXT:      |     `Results`
-//CHECK-NEXT:      |       `-VariableDecl {{.*}} Name<> Type<Attr>
-//CHECK-NEXT:      |         `Constraints`
-//CHECK-NEXT:      |           `-AttrConstraintDecl {{.*}}
+//CHECK-NEXT:      |-AttributeExpr {{.*}} Value<"{}">
 //CHECK-NEXT:      |-DeclRefExpr {{.*}} Type<Attr>
 //CHECK-NEXT:      | `-VariableDecl {{.*}} Name<dict0> Type<Attr>
 //CHECK-NEXT:      |   `-AttributeExpr {{.*}} Value<""test"">

--- a/mlir/test/mlir-pdll/Parser/expr.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr.pdll
@@ -4,8 +4,8 @@
 // AttrExpr
 //===----------------------------------------------------------------------===//
 
-// CHECK: Module
-// CHECK: `-AttributeExpr {{.*}} Value<"10: i32">
+// CHECK-LABEL: Module
+// CHECK: AttributeExpr {{.*}} Value<"10: i32">
 Pattern {
   let attr = attr<"10: i32">;
 
@@ -14,7 +14,7 @@ Pattern {
 
 // -----
 
-// CHECK: Module
+// CHECK-LABEL: Module
 // CHECK: `-AttributeExpr {{.*}} Value<"10:i32">
 Pattern {
   let attr = 10 : i32;
@@ -23,7 +23,7 @@ Pattern {
 
 // -----
 
-// CHECK: Module
+// CHECK-LABEL: Module
 // CHECK: `-AttributeExpr {{.*}} Value<""value"">
 Pattern {
   let attr = "value";

--- a/mlir/unittests/Dialect/PDL/BuiltinTest.cpp
+++ b/mlir/unittests/Dialect/PDL/BuiltinTest.cpp
@@ -41,16 +41,6 @@ public:
   TestPatternRewriter rewriter{&ctx};
 };
 
-TEST_F(BuiltinTest, createDictionaryAttr) {
-  TestPDLResultList results(1);
-  EXPECT_TRUE(succeeded(builtin::createDictionaryAttr(rewriter, results, {})));
-  ASSERT_TRUE(results.getResults().size() == 1);
-  auto dict = dyn_cast_or_null<DictionaryAttr>(
-      results.getResults().back().cast<Attribute>());
-  ASSERT_TRUE(dict);
-  EXPECT_TRUE(dict.empty());
-}
-
 TEST_F(BuiltinTest, addEntryToDictionaryAttr) {
   TestPDLResultList results(1);
 
@@ -75,19 +65,12 @@ TEST_F(BuiltinTest, addEntryToDictionaryAttr) {
   EXPECT_TRUE(cast<DictionaryAttr>(second).contains("testAttr2"));
 }
 
-TEST_F(BuiltinTest, createArrayAttr) {
-  auto attr = builtin::createArrayAttr(rewriter);
-  auto dict = dyn_cast<ArrayAttr>(attr);
-  EXPECT_TRUE(dict);
-  EXPECT_TRUE(dict.empty());
-}
-
 TEST_F(BuiltinTest, addElemToArrayAttr) {
   auto dict = rewriter.getDictionaryAttr(
       rewriter.getNamedAttr("key", rewriter.getStringAttr("value")));
   rewriter.getArrayAttr({});
 
-  auto arrAttr = builtin::createArrayAttr(rewriter);
+  auto arrAttr = rewriter.getArrayAttr({});
   mlir::Attribute updatedArrAttr =
       builtin::addElemToArrayAttr(rewriter, arrAttr, dict);
 


### PR DESCRIPTION
Instead of using native calls to create array/dict attributes, use the pdl.attribute op.