### PR TITLE
[Github] Fix typo in PR code formatting job

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Fetch code formatting utils
         uses: actions/checkout@v4
         with:
-          reository: ${{ github.repository }}
+          repository: ${{ github.repository }}
           ref: ${{ github.base_ref }}
           sparse-checkout: |
             llvm/utils/git/requirements_formatting.txt


### PR DESCRIPTION
This is a hotfix using commit f6c87be1 from upstream to get CI to pass on `feature/fused-ops` before carrying on further bumping. One review will be enough.

The recent change to split the PR code formatting job accidentally misspelled the repository field when specifying the repository to fetch the code formatting utils from. This patch fixes the spelling so that the job does not throw a warning and clones the tools from the specified repository.