### PR TITLE
Run code formatter on PRs targeting feature/fused-ops

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
-          ref: ${{ github.base_ref }}
+          ref: feature/fused-ops
           sparse-checkout: |
             llvm/utils/git/requirements_formatting.txt
             llvm/utils/git/code-format-helper.py

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -2,7 +2,7 @@ name: "Check code formatting"
 on:
   pull_request:
     branches:
-      - main
+      - feature/fused-ops
 
 jobs:
   code_formatter:
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
-          ref: feature/fused-ops
+          ref: ${{ github.base_ref }}
           sparse-checkout: |
             llvm/utils/git/requirements_formatting.txt
             llvm/utils/git/code-format-helper.py


### PR DESCRIPTION
This PR moves the code checking step from merging to `main` to PRs targeting `feature/fused-ops`. Since we're using `feature/fused-ops` as our main branch in this repo, we'll check code formatting of PRs that target `feature/fused-ops` instead of `main`.

This PR will fix the issue we're currently having with CI (failing code formatting step after merging into `feature/fused-ops`): since our `main` is late with respect to LLVM's, the script's version in `main` is too old and is missing one argument that our branch `feature/fused-ops` wants.