### PR TITLE
[FXML-4791] Hotfix to function assembly printer

### DIFF
--- a/mlir/lib/Dialect/EmitC/IR/FunctionOpAssembly.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/FunctionOpAssembly.cpp
@@ -244,10 +244,14 @@ void printFunctionSignature(OpAsmPrinter &p, FuncOp op, ArrayRef<Type> argTypes,
 
     // Exclude reference attribute if there is to replace it by ref
     SmallVector<NamedAttribute> attrs;
+    bool isReference = false;
     if (argAttrs) {
       for (auto attr : llvm::cast<DictionaryAttr>(argAttrs[i]).getValue()) {
-        if (attr.getName() != emitc::getReferenceAttributeName())
+        if (attr.getName() != emitc::getReferenceAttributeName()) {
           attrs.push_back(attr);
+        } else {
+          isReference = true;
+        }
       }
     }
 
@@ -258,6 +262,9 @@ void printFunctionSignature(OpAsmPrinter &p, FuncOp op, ArrayRef<Type> argTypes,
       if (argAttrs)
         p.printOptionalAttrDict(attrs);
     }
+
+    if (isReference)
+      p << " ref";
   }
 
   if (isVariadic) {

--- a/mlir/test/Dialect/EmitC/func.mlir
+++ b/mlir/test/Dialect/EmitC/func.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -split-input-file
+// RUN: mlir-opt %s -split-input-file | FileCheck %s
 
 // CHECK: emitc.func @f
 // CHECK-SAME: %{{[^:]*}}: i32 ref


### PR DESCRIPTION
The EmitC function assembly printer failed to print "ref" next to reference arguments, and the test wouldn't pick it up because it wouldn't run FileCheck. This PR gets all of that fixed.