### PR TITLE
[FXML-5083] SCFToEmitC: use already lowered operands

### DIFF
--- a/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
+++ b/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
@@ -113,7 +113,7 @@ ForLowering::matchAndRewrite(ForOp forOp, OpAdaptor adaptor,
     return rewriter.notifyMatchFailure(forOp,
                                        "create variables for results failed");
 
-  assignValues(forOp.getInits(), resultVariables, rewriter, loc);
+  assignValues(adaptor.getInitArgs(), resultVariables, rewriter, loc);
 
   emitc::ForOp loweredFor = rewriter.create<emitc::ForOp>(
       loc, adaptor.getLowerBound(), adaptor.getUpperBound(), adaptor.getStep());


### PR DESCRIPTION
The lowering of `scf.for` ops uses the non-lowered operands, which breaks when these operands have undergone EmitC lowering.