### PR TITLE
EmitC array type : verify dynamic shape before negative size

### DIFF
--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -969,10 +969,10 @@ LogicalResult emitc::ArrayType::verify(
     return emitError() << "shape must not be empty";
 
   for (int64_t dim : shape) {
-    if (dim < 0)
-      return emitError() << "dimensions must have non-negative size";
     if (dim == ShapedType::kDynamic)
       return emitError() << "dimensions must have static size";
+    if (dim < 0)
+      return emitError() << "dimensions must have non-negative size";
   }
 
   if (!elementType)


### PR DESCRIPTION
Unfortunately, we can't test this other than with a C++ test, as the MLIR parser will catch the error on its own before we reach `emitc::ArrayType::verify()`.