### PR TITLE
[FXML-5071] Add option to initialize UB.poison variables

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -1220,6 +1220,11 @@ def ConvertUBToEmitC : Pass<"convert-ub-to-emitc"> {
     This pass converts supported UB ops to EmitC dialect.
   }];
   let dependentDialects = ["emitc::EmitCDialect"];
+  let options = [
+    Option<"noInitialization", "no-initialization", "bool",
+           /*default=*/"false",
+           "Do not initialize the generated variables">,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Conversion/UBToEmitC/UBToEmitC.h
+++ b/mlir/include/mlir/Conversion/UBToEmitC/UBToEmitC.h
@@ -18,7 +18,8 @@ namespace mlir {
 
 namespace ub {
 void populateUBToEmitCConversionPatterns(TypeConverter &converter,
-                                         RewritePatternSet &patterns);
+                                         RewritePatternSet &patterns,
+                                         bool noInitialization);
 } // namespace ub
 } // namespace mlir
 

--- a/mlir/lib/Conversion/UBToEmitC/UBToEmitC.cpp
+++ b/mlir/lib/Conversion/UBToEmitC/UBToEmitC.cpp
@@ -26,7 +26,13 @@ using namespace mlir;
 
 namespace {
 struct PoisonOpLowering : public OpConversionPattern<ub::PoisonOp> {
-  using OpConversionPattern::OpConversionPattern;
+  bool noInitialization;
+
+public:
+  PoisonOpLowering(const TypeConverter &converter, MLIRContext *context,
+                   bool noInitialization)
+      : OpConversionPattern<ub::PoisonOp>(converter, context),
+        noInitialization(noInitialization) {}
 
   LogicalResult
   matchAndRewrite(ub::PoisonOp op, OpAdaptor adaptor,
@@ -43,18 +49,33 @@ struct PoisonOpLowering : public OpConversionPattern<ub::PoisonOp> {
           op.getLoc(), "only scalar poison values can be lowered");
     }
 
+    Attribute value;
+
+    if (noInitialization) {
+      value = emitc::OpaqueAttr::get(op->getContext(), "");
+    }
+    if (!noInitialization && emitc::isIntegerIndexOrOpaqueType(convertedType)) {
+      value = IntegerAttr::get((emitc::isPointerWideType(convertedType))
+                                   ? IndexType::get(op.getContext())
+                                   : convertedType,
+                               42);
+    }
+    if (!noInitialization && emitc::isSupportedFloatType(convertedType)) {
+      value = FloatAttr::get(convertedType, 42.0f);
+    }
+
     // Any constant will be fine to lower a poison op
-    rewriter.replaceOpWithNewOp<emitc::VariableOp>(
-        op, convertedType, emitc::OpaqueAttr::get(op->getContext(), ""));
+    rewriter.replaceOpWithNewOp<emitc::VariableOp>(op, convertedType, value);
     return success();
   }
 };
 } // namespace
 
 void ub::populateUBToEmitCConversionPatterns(TypeConverter &converter,
-                                             RewritePatternSet &patterns) {
+                                             RewritePatternSet &patterns,
+                                             bool noInitialization) {
   MLIRContext *ctx = patterns.getContext();
-  patterns.add<PoisonOpLowering>(converter, ctx);
+  patterns.add<PoisonOpLowering>(converter, ctx, noInitialization);
 }
 
 struct ConvertUBToEmitC : public impl::ConvertUBToEmitCBase<ConvertUBToEmitC> {
@@ -70,7 +91,8 @@ struct ConvertUBToEmitC : public impl::ConvertUBToEmitCBase<ConvertUBToEmitC> {
     target.addLegalDialect<emitc::EmitCDialect>();
     target.addIllegalDialect<ub::UBDialect>();
 
-    mlir::ub::populateUBToEmitCConversionPatterns(converter, patterns);
+    mlir::ub::populateUBToEmitCConversionPatterns(converter, patterns,
+                                                  noInitialization);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))

--- a/mlir/lib/Conversion/UBToEmitC/UBToEmitC.cpp
+++ b/mlir/lib/Conversion/UBToEmitC/UBToEmitC.cpp
@@ -50,17 +50,14 @@ public:
     }
 
     Attribute value;
-
     if (noInitialization) {
       value = emitc::OpaqueAttr::get(op->getContext(), "");
-    }
-    if (!noInitialization && emitc::isIntegerIndexOrOpaqueType(convertedType)) {
+    } else if (emitc::isIntegerIndexOrOpaqueType(convertedType)) {
       value = IntegerAttr::get((emitc::isPointerWideType(convertedType))
                                    ? IndexType::get(op.getContext())
                                    : convertedType,
                                42);
-    }
-    if (!noInitialization && emitc::isSupportedFloatType(convertedType)) {
+    } else if (emitc::isSupportedFloatType(convertedType)) {
       value = FloatAttr::get(convertedType, 42.0f);
     }
 

--- a/mlir/test/Conversion/UBToEmitC/convert-ub-to-emitc-no-init.mlir
+++ b/mlir/test/Conversion/UBToEmitC/convert-ub-to-emitc-no-init.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-opt -p 'builtin.module(convert-ub-to-emitc{no-initialization})' %s | FileCheck %s
+
+// CHECK-LABEL: func.func @poison
+func.func @poison() {
+  // CHECK: "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
+  %0 = ub.poison : i32
+  // CHECK: "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
+  %1 = ub.poison : f32
+  // CHECK: "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.size_t
+  %2 = ub.poison : index
+  return
+}

--- a/mlir/test/Conversion/UBToEmitC/convert-ub-to-emitc.mlir
+++ b/mlir/test/Conversion/UBToEmitC/convert-ub-to-emitc.mlir
@@ -2,11 +2,11 @@
 
 // CHECK-LABEL: func.func @poison
 func.func @poison() {
-  // CHECK: "emitc.variable"{{.*}} -> i32
+  // CHECK: "emitc.variable"() <{value = 42 : i32}> : () -> i32
   %0 = ub.poison : i32
-  // CHECK: "emitc.variable"{{.*}} -> f32
+  // CHECK: "emitc.variable"() <{value = 4.200000e+01 : f32}> : () -> f32
   %1 = ub.poison : f32
-  // CHECK: "emitc.variable"{{.*}} -> !emitc.size_t
+  // CHECK: "emitc.variable"() <{value = 42 : index}> : () -> !emitc.size_t
   %2 = ub.poison : index
   return
 }


### PR DESCRIPTION
This changes the behavior of `ub-to-emitc` to initialize variables to 42 by default, and adds an option to to skip this initialization.