### PR TITLE
Don't print semicolon after emitc.verbatim within emitc.for

### DIFF
--- a/mlir/test/Target/Cpp/verbatim.mlir
+++ b/mlir/test/Target/Cpp/verbatim.mlir
@@ -40,6 +40,18 @@ emitc.func @func(%arg: f32) {
 
   emitc.verbatim "#pragma my2 var={} property" %a : !emitc.array<3x7xi32>
   // CHECK-NEXT: #pragma my2 var=[[A]] property
+  emitc.return
+}
 
+// Check that no semicolon is printed after verbatim within emitc.for
+emitc.func @in_loop(%arg: f32) {
+  %start = emitc.literal "0" : !emitc.size_t
+  %stop = emitc.literal "10" : !emitc.size_t
+  %step = emitc.literal "1" : !emitc.size_t
+  emitc.for %iter = %start to %stop step %step {
+    emitc.verbatim "#pragma"
+     // CHECK: #pragma
+    emitc.yield
+  }
   emitc.return
 }


### PR DESCRIPTION
There was code to suppress printing semicolons after emitc.verbatim in the function that emits a function body, but then it would still print `#pragma;` when the `emitc.verbatim "#pragma"` was within a loop body.

I moved that code into the general printOperation() function, so it applies to emitc.verbatim independent of what the parent op is.