### PR TITLE
emitc.tu: Automatically create block for body

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -85,7 +85,11 @@ def EmitC_TranslationUnitOp : EmitC_Op<"tu",
   let regions = (region SizedRegion<1>:$bodyRegion);
 
   let assemblyFormat = "$id attr-dict-with-keyword $bodyRegion";
+  let builders = [OpBuilder<(ins CArg<"StringRef">:$id)>];
   let extraClassDeclaration = [{
+    /// Construct a module from the given location with an optional name.
+    static TranslationUnitOp create(Location loc, StringRef name);
+
     //===------------------------------------------------------------------===//
     // OpAsmOpInterface Methods
     //===------------------------------------------------------------------===//
@@ -96,6 +100,10 @@ def EmitC_TranslationUnitOp : EmitC_Op<"tu",
       return "emitc";
     }
   }];
+
+  // We need to ensure that the body region has a block;
+  // the auto-generated builders do not guarantee that.
+  let skipDefaultBuilders = 1;
 }
 
 def EmitC_AddOp : EmitC_BinaryOp<"add", [CExpression]> {

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -1252,6 +1252,16 @@ GetGlobalOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
+// TranslationUnitOp
+//===----------------------------------------------------------------------===//
+void TranslationUnitOp::build(OpBuilder &builder, OperationState &state,
+                              StringRef id) {
+  state.addRegion()->emplaceBlock();
+  state.attributes.push_back(
+      builder.getNamedAttr("id", builder.getStringAttr(id)));
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen'd op method definitions
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
The auto-generated builder created an emitc.tu that had an empty region. This is a bit cumbersome to work with, as you would always manually needed to create a block in it.
Do what ModuleOp::build does and always create that block.

Also accept StringRef as argument for id instead of requiring a StringAttr.