### PR TITLE
emitc.include: don't require the parent to be a ModuleOp

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -774,7 +774,7 @@ def EmitC_ReturnOp : EmitC_Op<"return", [Pure, HasParent<"FuncOp">,
 }
 
 def EmitC_IncludeOp
-    : EmitC_Op<"include", [HasParent<"ModuleOp">]> {
+    : EmitC_Op<"include", []> {
   let summary = "Include operation";
   let description = [{
     The `emitc.include` operation allows to define a source file inclusion via the


### PR DESCRIPTION
`#include` make sense everywhere, and in particular we need to allow them inside a `emitc.tu`. But sometimes we might even want to have an `#include` in a function body.