### PR TITLE
fix: fuse locations of double reshapes when folding.

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1107,6 +1107,10 @@ OpFoldResult ReshapeOp::fold(FoldAdaptor adaptor) {
   if (auto reshapeOp = llvm::dyn_cast_if_present<tosa::ReshapeOp>(
           getInput1().getDefiningOp())) {
     getInput1Mutable().assign(reshapeOp.getInput1());
+
+    // Fuse locations so that first ReshapeOp location isn't lost.
+    getResult().getDefiningOp()->setLoc(
+        mlir::FusedLoc::get(getContext(), {reshapeOp->getLoc(), getLoc()}));
     return getResult();
   }
 


### PR DESCRIPTION
Issue: when folding two reshapes, we were losing the location of the first one.

PS.: there are more operations with a similar issue, but let's address them later. 