### PR TITLE
ArithToEmitC: Support using opaque types for floating point

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.h
@@ -46,6 +46,10 @@ bool isIntegerIndexOrOpaqueType(Type type);
 /// Determines whether \p type is a valid floating-point type in EmitC.
 bool isSupportedFloatType(mlir::Type type);
 
+/// Determines whether \p type is a valid floating-point or opaque type in
+/// EmitC.
+bool isFloatOrOpaqueType(mlir::Type type);
+
 /// Determines whether \p type is a emitc.size_t/ssize_t type.
 bool isPointerWideType(mlir::Type type);
 

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -307,7 +307,7 @@ public:
           "negf currently only supports scalar types, not vectors or tensors");
     }
 
-    if (!emitc::isSupportedFloatType(adaptedOpType)) {
+    if (!emitc::isFloatOrOpaqueType(adaptedOpType)) {
       return rewriter.notifyMatchFailure(
           op.getLoc(), "floating-point type is not supported by EmitC");
     }
@@ -655,7 +655,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     Type operandType = adaptor.getIn().getType();
-    if (!emitc::isSupportedFloatType(operandType))
+    if (!emitc::isFloatOrOpaqueType(operandType))
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast source type");
 
@@ -710,7 +710,7 @@ public:
     if (!dstType)
       return rewriter.notifyMatchFailure(castOp, "type conversion failed");
 
-    if (!emitc::isSupportedFloatType(dstType))
+    if (!emitc::isFloatOrOpaqueType(dstType))
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast destination type");
 
@@ -745,7 +745,7 @@ public:
     // attribute that we need to check. For now, the behavior is the default,
     // i.e. truncate.
     Type operandType = adaptor.getIn().getType();
-    if (!emitc::isSupportedFloatType(operandType))
+    if (!emitc::isFloatOrOpaqueType(operandType))
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast source type");
 
@@ -753,7 +753,7 @@ public:
     if (!dstType)
       return rewriter.notifyMatchFailure(castOp, "type conversion failed");
 
-    if (!emitc::isSupportedFloatType(dstType))
+    if (!emitc::isFloatOrOpaqueType(dstType))
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast destination type");
 
@@ -775,7 +775,7 @@ public:
   matchAndRewrite(arith::ExtFOp castOp, typename arith::ExtFOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type operandType = adaptor.getIn().getType();
-    if (!emitc::isSupportedFloatType(operandType))
+    if (!emitc::isFloatOrOpaqueType(operandType))
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast source type");
 
@@ -783,7 +783,7 @@ public:
     if (!dstType)
       return rewriter.notifyMatchFailure(castOp, "type conversion failed");
 
-    if (!emitc::isSupportedFloatType(dstType))
+    if (!emitc::isFloatOrOpaqueType(dstType))
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast destination type");
 

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -119,6 +119,10 @@ bool mlir::emitc::isSupportedFloatType(Type type) {
   return isa<Float32Type, Float64Type>(type);
 }
 
+bool mlir::emitc::isFloatOrOpaqueType(Type type) {
+  return llvm::isa<emitc::OpaqueType>(type) || isSupportedFloatType(type);
+}
+
 bool mlir::emitc::isPointerWideType(Type type) {
   return isa<emitc::SignedSizeTType, emitc::SizeTType, emitc::PtrDiffTType>(
       type);

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -120,7 +120,7 @@ bool mlir::emitc::isSupportedFloatType(Type type) {
 }
 
 bool mlir::emitc::isFloatOrOpaqueType(Type type) {
-  return llvm::isa<emitc::OpaqueType>(type) || isSupportedFloatType(type);
+  return isa<emitc::OpaqueType>(type) || isSupportedFloatType(type);
 }
 
 bool mlir::emitc::isPointerWideType(Type type) {


### PR DESCRIPTION
Ensure that floating point ops allow their target type to be emitc.opaque.