### PR TITLE
computeSliceParameters: use full slice if affine exprs are non-monotonic

### DIFF
--- a/mlir/include/mlir/IR/AffineExpr.h
+++ b/mlir/include/mlir/IR/AffineExpr.h
@@ -110,6 +110,11 @@ public:
   /// floordiv, ceildiv, and mod is only allowed w.r.t constants.
   bool isPureAffine() const;
 
+  /// Returns true if this expression is monotonic with respect to the
+  /// AffineDimExpr, i.e. increasing the value of any AffineDimExpr will never
+  /// decrease the value of the result.
+  bool isMonotonic() const;
+
   /// Returns the greatest known integral divisor of this affine expression. The
   /// result is always positive.
   int64_t getLargestKnownDivisor() const;

--- a/mlir/include/mlir/IR/AffineExpr.h
+++ b/mlir/include/mlir/IR/AffineExpr.h
@@ -110,10 +110,10 @@ public:
   /// floordiv, ceildiv, and mod is only allowed w.r.t constants.
   bool isPureAffine() const;
 
-  /// Returns true if this expression is monotonic with respect to the
-  /// AffineDimExpr, i.e. increasing the value of any AffineDimExpr will never
-  /// decrease the value of the result.
-  bool isMonotonic() const;
+  /// Returns true if this expression is monotonicically increasing with respect
+  /// to the AffineDimExprs, i.e. increasing the value of any AffineDimExpr will
+  /// never decrease the value of the result.
+  bool isMonotonicallyIncreasing() const;
 
   /// Returns the greatest known integral divisor of this affine expression. The
   /// result is always positive.

--- a/mlir/include/mlir/IR/AffineMap.h
+++ b/mlir/include/mlir/IR/AffineMap.h
@@ -364,8 +364,9 @@ public:
   /// Returns true if the AffineMap represents a symbol-less permutation map.
   bool isPermutation() const;
 
-  // Returns true if every result is monotonic.
-  bool isMonotonic() const;
+  // Returns true if every result is monotonically increasing.
+  // See AffineExpr::isMonotonicallyIncreasing().
+  bool isComponentWiseMonotonicallyIncreasing() const;
 
   /// Returns the map consisting of the `resultPos` subset.
   AffineMap getSubMap(ArrayRef<unsigned> resultPos) const;

--- a/mlir/include/mlir/IR/AffineMap.h
+++ b/mlir/include/mlir/IR/AffineMap.h
@@ -364,6 +364,9 @@ public:
   /// Returns true if the AffineMap represents a symbol-less permutation map.
   bool isPermutation() const;
 
+  // Returns true if every result is monotonic.
+  bool isMonotonic() const;
+
   /// Returns the map consisting of the `resultPos` subset.
   AffineMap getSubMap(ArrayRef<unsigned> resultPos) const;
 

--- a/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
@@ -618,8 +618,8 @@ computeSliceParameters(OpBuilder &builder, Location loc, Value valueToTile,
     LLVM_DEBUG(llvm::dbgs() << "computeSliceParameters: for dim#" << r);
     auto m = map.getSubMap({r});
     // The offset & size computation below only handles the case when
-    // the map is monotonic, i.e. the min and max values are attained at the
-    // lower and upper bounds of the iteration domain.
+    // the map is monotonically increasing, i.e. the min and max values are
+    // attained at the lower and upper bounds of the iteration domain.
     if (!isTiled(m, tileSizes) || !m.isComponentWiseMonotonicallyIncreasing()) {
       sliceParams.offsets.push_back(builder.getIndexAttr(0));
       OpFoldResult dim = createFoldedDimOp(builder, loc, valueToTile, r);

--- a/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
@@ -616,7 +616,11 @@ computeSliceParameters(OpBuilder &builder, Location loc, Value valueToTile,
   sliceParams.strides.reserve(rank);
   for (unsigned r = 0; r < rank; ++r) {
     LLVM_DEBUG(llvm::dbgs() << "computeSliceParameters: for dim#" << r);
-    if (!isTiled(map.getSubMap({r}), tileSizes)) {
+    auto m = map.getSubMap({r});
+    // The offset & size computation below only handles the case when
+    // the map is monotonic, i.e. the min and max values are attained at the
+    // lower and upper bounds of the iteration domain.
+    if (!isTiled(m, tileSizes) || !m.isMonotonic()) {
       sliceParams.offsets.push_back(builder.getIndexAttr(0));
       OpFoldResult dim = createFoldedDimOp(builder, loc, valueToTile, r);
       sliceParams.sizes.push_back(dim);
@@ -628,7 +632,6 @@ computeSliceParameters(OpBuilder &builder, Location loc, Value valueToTile,
 
     // Tiling creates a new slice at the proper index, the slice step is 1
     // (i.e. the op does not subsample, stepping occurs in the loop).
-    auto m = map.getSubMap({r});
     LLVM_DEBUG(llvm::dbgs() << "computeSliceParameters: submap: " << m << "\n");
     IRRewriter rewriter(builder);
     OpFoldResult offset = makeComposedFoldedAffineApply(rewriter, loc, m, lbs);

--- a/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
@@ -620,7 +620,7 @@ computeSliceParameters(OpBuilder &builder, Location loc, Value valueToTile,
     // The offset & size computation below only handles the case when
     // the map is monotonic, i.e. the min and max values are attained at the
     // lower and upper bounds of the iteration domain.
-    if (!isTiled(m, tileSizes) || !m.isMonotonic()) {
+    if (!isTiled(m, tileSizes) || !m.isComponentWiseMonotonicallyIncreasing()) {
       sliceParams.offsets.push_back(builder.getIndexAttr(0));
       OpFoldResult dim = createFoldedDimOp(builder, loc, valueToTile, r);
       sliceParams.sizes.push_back(dim);

--- a/mlir/lib/IR/AffineExpr.cpp
+++ b/mlir/lib/IR/AffineExpr.cpp
@@ -244,7 +244,7 @@ static bool isNonNegativeConstant(AffineExpr expr) {
   return constant && constant.getValue() >= 0;
 }
 
-bool AffineExpr::isMonotonic() const {
+bool AffineExpr::isMonotonicallyIncreasing() const {
   switch (getKind()) {
   case AffineExprKind::SymbolId:
   case AffineExprKind::DimId:
@@ -252,19 +252,22 @@ bool AffineExpr::isMonotonic() const {
     return true;
   case AffineExprKind::Add: {
     auto op = llvm::cast<AffineBinaryOpExpr>(*this);
-    return op.getLHS().isMonotonic() && op.getRHS().isMonotonic();
+    return op.getLHS().isMonotonicallyIncreasing() &&
+           op.getRHS().isMonotonicallyIncreasing();
   }
   case AffineExprKind::Mul: {
     // One operand must be a non-negative constant.
     auto op = llvm::cast<AffineBinaryOpExpr>(*this);
-    return op.getLHS().isMonotonic() && op.getRHS().isMonotonic() &&
+    return op.getLHS().isMonotonicallyIncreasing() &&
+           op.getRHS().isMonotonicallyIncreasing() &&
            (isNonNegativeConstant(op.getLHS()) ||
             isNonNegativeConstant(op.getRHS()));
   }
   case AffineExprKind::FloorDiv:
   case AffineExprKind::CeilDiv: {
     auto op = llvm::cast<AffineBinaryOpExpr>(*this);
-    return op.getLHS().isMonotonic() && isNonNegativeConstant(op.getRHS());
+    return op.getLHS().isMonotonicallyIncreasing() &&
+           isNonNegativeConstant(op.getRHS());
   }
   case AffineExprKind::Mod:
     return false;

--- a/mlir/lib/IR/AffineExpr.cpp
+++ b/mlir/lib/IR/AffineExpr.cpp
@@ -239,6 +239,39 @@ bool AffineExpr::isPureAffine() const {
   llvm_unreachable("Unknown AffineExpr");
 }
 
+static bool isNonNegativeConstant(AffineExpr expr) {
+  auto constant = dyn_cast<AffineConstantExpr>(expr);
+  return constant && constant.getValue() >= 0;
+}
+
+bool AffineExpr::isMonotonic() const {
+  switch (getKind()) {
+  case AffineExprKind::SymbolId:
+  case AffineExprKind::DimId:
+  case AffineExprKind::Constant:
+    return true;
+  case AffineExprKind::Add: {
+    auto op = llvm::cast<AffineBinaryOpExpr>(*this);
+    return op.getLHS().isMonotonic() && op.getRHS().isMonotonic();
+  }
+  case AffineExprKind::Mul: {
+    // One operand must be a non-negative constant.
+    auto op = llvm::cast<AffineBinaryOpExpr>(*this);
+    return op.getLHS().isMonotonic() && op.getRHS().isMonotonic() &&
+           (isNonNegativeConstant(op.getLHS()) ||
+            isNonNegativeConstant(op.getRHS()));
+  }
+  case AffineExprKind::FloorDiv:
+  case AffineExprKind::CeilDiv: {
+    auto op = llvm::cast<AffineBinaryOpExpr>(*this);
+    return op.getLHS().isMonotonic() && isNonNegativeConstant(op.getRHS());
+  }
+  case AffineExprKind::Mod:
+    return false;
+  }
+  llvm_unreachable("Unknown AffineExpr");
+}
+
 // Returns the greatest known integral divisor of this affine expression.
 int64_t AffineExpr::getLargestKnownDivisor() const {
   AffineBinaryOpExpr binExpr(nullptr);

--- a/mlir/lib/IR/AffineMap.cpp
+++ b/mlir/lib/IR/AffineMap.cpp
@@ -628,8 +628,9 @@ bool AffineMap::isPermutation() const {
   return isProjectedPermutation();
 }
 
-bool AffineMap::isMonotonic() const {
-  return all_of(getResults(), [](auto expr) { return expr.isMonotonic(); });
+bool AffineMap::isComponentWiseMonotonicallyIncreasing() const {
+  return all_of(getResults(),
+                [](auto expr) { return expr.isMonotonicallyIncreasing(); });
 }
 
 AffineMap AffineMap::getSubMap(ArrayRef<unsigned> resultPos) const {

--- a/mlir/lib/IR/AffineMap.cpp
+++ b/mlir/lib/IR/AffineMap.cpp
@@ -628,6 +628,10 @@ bool AffineMap::isPermutation() const {
   return isProjectedPermutation();
 }
 
+bool AffineMap::isMonotonic() const {
+  return all_of(getResults(), [](auto expr) { return expr.isMonotonic(); });
+}
+
 AffineMap AffineMap::getSubMap(ArrayRef<unsigned> resultPos) const {
   SmallVector<AffineExpr, 4> exprs;
   exprs.reserve(resultPos.size());


### PR DESCRIPTION
`computeSliceParameters` maps the loop range (given by lower bounds `lbs` and upper bounds `ubs`) into the operand tensor to compute the input slices that contains all indexed values.

The computation currently assumes that the affine expressions to map from loop iteration domain to tensor domain are monotonic, and use that information by just evaluating those at `lbs` and `ubs` to obtain the slice o the operand tensor.
For non-monotonic expressions, the maximum and minimum values might not be at the boundaries.
Detect that case, and then use the full slice to be safe.

Fixes #111830

If shapes are static, we could be cleverer: sometimes we can prove that even though the affine expression is not monotonic in itself, it is monotonic on the range `(lbs, ubs)`. For example when the affine expression contains a `d0 mod 8`, and the range is `(0, 4)`.