### PR TITLE
EmitC: Allow casts between opaque and float types

### DIFF
--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -757,7 +757,9 @@ public:
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast destination type");
 
-    if (!castOp.areCastCompatible(operandType, dstType))
+    if (!isa<emitc::OpaqueType>(dstType) &&
+        !isa<emitc::OpaqueType>(operandType) &&
+        !castOp.areCastCompatible(operandType, dstType))
       return rewriter.notifyMatchFailure(castOp, "cast-incompatible types");
 
     rewriter.replaceOpWithNewOp<emitc::CastOp>(castOp, dstType,
@@ -787,7 +789,9 @@ public:
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast destination type");
 
-    if (!castOp.areCastCompatible(operandType, dstType))
+    if (!isa<emitc::OpaqueType>(dstType) &&
+        !isa<emitc::OpaqueType>(operandType) &&
+        !castOp.areCastCompatible(operandType, dstType))
       return rewriter.notifyMatchFailure(castOp, "cast-incompatible types");
 
     rewriter.replaceOpWithNewOp<emitc::CastOp>(castOp, dstType,

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -757,9 +757,7 @@ public:
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast destination type");
 
-    if (!isa<emitc::OpaqueType>(dstType) &&
-        !isa<emitc::OpaqueType>(operandType) &&
-        !castOp.areCastCompatible(operandType, dstType))
+    if (!emitc::CastOp::areCastCompatible(operandType, dstType))
       return rewriter.notifyMatchFailure(castOp, "cast-incompatible types");
 
     rewriter.replaceOpWithNewOp<emitc::CastOp>(castOp, dstType,
@@ -789,9 +787,7 @@ public:
       return rewriter.notifyMatchFailure(castOp,
                                          "unsupported cast destination type");
 
-    if (!isa<emitc::OpaqueType>(dstType) &&
-        !isa<emitc::OpaqueType>(operandType) &&
-        !castOp.areCastCompatible(operandType, dstType))
+    if (!emitc::CastOp::areCastCompatible(operandType, dstType))
       return rewriter.notifyMatchFailure(castOp, "cast-incompatible types");
 
     rewriter.replaceOpWithNewOp<emitc::CastOp>(castOp, dstType,

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -313,6 +313,10 @@ LogicalResult emitc::AssignOp::verify() {
 bool CastOp::areCastCompatible(TypeRange inputs, TypeRange outputs) {
   Type input = inputs.front(), output = outputs.front();
 
+  // Opaque types are always allowed
+  if (isa<emitc::OpaqueType>(input) || isa<emitc::OpaqueType>(output))
+    return true;
+
   // Cast to array is only possible from an array
   if (isa<emitc::ArrayType>(input) != isa<emitc::ArrayType>(output))
     return false;

--- a/mlir/test/Dialect/EmitC/ops.mlir
+++ b/mlir/test/Dialect/EmitC/ops.mlir
@@ -36,11 +36,15 @@ emitc.func private @extern(i32) attributes {specifiers = ["extern"]}
 
 func.func @cast(%arg0: i32) {
   %1 = emitc.cast %arg0: i32 to f32
+  %2 = emitc.cast %1: f32 to !emitc.opaque<"some type">
+  %3 = emitc.cast %2: !emitc.opaque<"some type"> to !emitc.size_t
   return
 }
 
 func.func @cast_array(%arg : !emitc.array<4xf32>) {
     %1 = emitc.cast %arg: !emitc.array<4xf32> to !emitc.array<4xf32> ref
+    %2 = emitc.cast %arg: !emitc.array<4xf32> to !emitc.opaque<"some type">
+    %3 = emitc.cast %2: !emitc.opaque<"some type"> to !emitc.array<4xf32> ref
     return
 }
 


### PR DESCRIPTION
I can unfortunately not really test this since there is not type conversion from float to an opaque type.
We might want some made-for-testing-purposes opaque type conversions (in a separate PR) to ensure that opaque type conversions are handled properly in all upstream lowerings.