### PR TITLE
Fix for upstream change in docker container

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -60,6 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:latest') || null}}
+      options: --user root
       volumes:
         - /mnt/:/mnt/
     strategy:


### PR DESCRIPTION
We use the docker image from upstream (`ghcr.io/llvm/ci-ubuntu-22.04:latest`), which changed recently to use a non-root users (b86a22aa3915).
Switch user back to `root`.