### PR TITLE
asan: replace used python in mlir lit.cfg with shim script

### DIFF
--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -70,13 +70,19 @@ def find_runtime(name):
             break
     return path
 
+
 # Find path to the ASan runtime required for the Python interpreter.
 def find_asan_runtime():
     if not "asan" in config.available_features or not "Linux" in config.host_os:
         return ""
     # Find the asan rt lib
     return (
-        subprocess.check_output([config.host_cxx.strip(), f"-print-file-name=libclang_rt.asan-{config.host_arch}.so"])
+        subprocess.check_output(
+            [
+                config.host_cxx.strip(),
+                f"-print-file-name=libclang_rt.asan-{config.host_arch}.so",
+            ]
+        )
         .decode("utf-8")
         .strip()
     )

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -177,7 +177,19 @@ python_executable = config.python_executable
 # Python configuration with sanitizer requires some magic preloading. This will only work on clang/linux.
 # TODO: detect Darwin/Windows situation (or mark these tests as unsupported on these platforms).
 if "asan" in config.available_features and "Linux" in config.host_os:
-    python_executable = f"LD_PRELOAD=$({config.host_cxx} -print-file-name=libclang_rt.asan-{config.host_arch}.so) {config.python_executable}"
+    # Write shim script that preloads the necessary shared object for ASAN tests. Fallback to such script for two reasons:
+    #
+    # (1) Provide full support for LLVM's test utils like `not`, which are prepended to the original statement containing the `LD_PRELOAD` env definition.
+    #     Having environment definitions in the middle of a command line is syntactically illegal.
+    # (2) Mitigate issues with LIT's internal shell that puts single quotes around the environment definition,
+    #     which leads to malformed command lines:
+    #     `LD_PRELOAD=$(/usr/bin/clang++-17' '-print-file-name=libclang_rt.asan-x86_64.so)' python (...)`
+    with open("python-asan-shim", "w") as file:
+        file.write(
+            f"#!/usr/bin/env bash\nLD_PRELOAD=$({config.host_cxx} -print-file-name=libclang_rt.asan-{config.host_arch}.so) {python_executable} $@\n"
+        )
+    os.chmod(os.path.abspath("python-asan-shim"), 0o700)
+    python_executable = os.path.abspath("python-asan-shim")
 # On Windows the path to python could contains spaces in which case it needs to be provided in quotes.
 # This is the equivalent of how %python is setup in llvm/utils/lit/lit/llvm/config.py.
 elif "Windows" in config.host_os:


### PR DESCRIPTION
This PR exchanges the used Python executable inside the MLIR LIT test suite, when the build is configured for utilizing ASan. The executable is replaced with a shim script, which preloads the necessary ASan shared object file as it did before, but additionally exhibits two benefits:

1. Provide full support for LLVM's test utils like `not`, which are prepended to the original statement containing the `LD_PRELOAD` env definition. Having environment definitions in the middle of a command line is syntactically illegal.
2. Mitigate issues with LIT's internal shell that puts single quotes around the environment definition, which leads to malformed command lines: `LD_PRELOAD=$(/usr/bin/clang++-17' '-print-file-name=libclang_rt.asan-x86_64.so)' python (...)`
    - The problem might be circumvented by disabling the LIT's internal shell through updating the environment with `LIT_USE_INTERNAL_SHELL=0`, but might not be desired for compatibility/stability reasons. 