### PR TITLE
[MLIR] control-flow-sink: Allow to configure shouldMoveIntoRegion

### DIFF
--- a/mlir/include/mlir/Transforms/Passes.h
+++ b/mlir/include/mlir/Transforms/Passes.h
@@ -66,7 +66,8 @@ createCanonicalizerPass(const GreedyRewriteConfig &config,
                         ArrayRef<std::string> enabledPatterns = std::nullopt);
 
 /// Creates a pass to perform control-flow sinking.
-std::unique_ptr<Pass> createControlFlowSinkPass();
+std::unique_ptr<Pass> createControlFlowSinkPass(
+    function_ref<bool(Operation *, Region *)> shouldMoveIntoRegion = nullptr);
 
 /// Creates a pass to perform common sub expression elimination.
 std::unique_ptr<Pass> createCSEPass();


### PR DESCRIPTION
Many places expect on `linalg.index` ops directly nested within `linalg.generic`, so it seems easier to just restrict the `control-flow-sink` pass from moving `linalg.index` ops.

To achieve that, I expose the `shouldMoveIntoRegion` option on the pass while keeping the default behavior the same.