### PR TITLE
Relax constraint that linalg.index must be directly within linalg.generic

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -2233,7 +2233,7 @@ LogicalResult linalg::YieldOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult IndexOp::verify() {
-  auto linalgOp = dyn_cast<LinalgOp>((*this)->getParentOp());
+  auto linalgOp = (*this)->getParentOfType<LinalgOp>();
   if (!linalgOp)
     return emitOpError("expected parent op with LinalgOp interface");
   if (linalgOp.getNumLoops() <= getDim())

--- a/mlir/lib/Dialect/Linalg/Transforms/Loops.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Loops.cpp
@@ -199,9 +199,11 @@ static void replaceIndexOpsByInductionVariables(RewriterBase &rewriter,
   // Replace the index operations in the body of the innermost loop op.
   if (!loopOps.empty()) {
     auto loopOp = cast<LoopLikeOpInterface>(loopOps.back());
-    for (Region *r : loopOp.getLoopRegions())
-      for (IndexOp indexOp : llvm::make_early_inc_range(r->getOps<IndexOp>()))
+    for (Region *r : loopOp.getLoopRegions()) {
+      r->walk([&](IndexOp indexOp) {
         rewriter.replaceOp(indexOp, allIvs[indexOp.getDim()]);
+      });
+    }
   }
 }
 

--- a/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
@@ -836,9 +836,9 @@ void offsetIndices(RewriterBase &b, LinalgOp linalgOp,
   if (!linalgOp.hasIndexSemantics())
     return;
 
-  for (IndexOp indexOp : linalgOp.getBlock()->getOps<IndexOp>()) {
+  linalgOp.walk([&](IndexOp indexOp) {
     if (indexOp.getDim() >= offsets.size() || !offsets[indexOp.getDim()])
-      continue;
+      return;
     OpBuilder::InsertionGuard guard(b);
     b.setInsertionPointAfter(indexOp);
     AffineExpr index, offset;
@@ -851,7 +851,7 @@ void offsetIndices(RewriterBase &b, LinalgOp linalgOp,
     b.replaceUsesWithIf(indexOp, materialized, [&](OpOperand &use) {
       return use.getOwner() != materialized.getDefiningOp();
     });
-  }
+  });
 }
 
 /// Get the reassociation maps to fold the result of a extract_slice (or source


### PR DESCRIPTION
This is not complete. Look for other uses of IndexOp, e.g. `getOps<IndexOp>`