### PR TITLE
tile_sort.mlir: Use --mlir-disable-threading to make test deterministic

### DIFF
--- a/mlir/test/Dialect/Linalg/tile-sort.mlir
+++ b/mlir/test/Dialect/Linalg/tile-sort.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -transform-interpreter -split-input-file -debug-only=tile-using-interface 2>&1 | FileCheck %s
+// RUN: mlir-opt %s -transform-interpreter -split-input-file -debug-only=tile-using-interface --mlir-disable-threading 2>&1 | FileCheck %s
 
 func.func @tile_order_ceil_then_negf(%arg: tensor<256xf32>) -> tensor<256xf32> {
   // Ops are tiled by lower priority: linalg.powf, linalg.ceil (1st operand of powf, priority = 0),


### PR DESCRIPTION
Hotfix after https://github.com/Xilinx/llvm-project/pull/532 to make sure the test doesn't randomly fail due to stdout/err intertwining.