### PR TITLE
Provide tile-and-fuse for SoftMax

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
@@ -101,7 +101,8 @@ def Linalg_SoftmaxOp : Linalg_Op<"softmax",
       ["getIterationDomain",
        "getLoopIteratorTypes",
        "getResultTilePosition",
-       "getTiledImplementation"]>]> {
+       "getTiledImplementation",
+       "generateResultTileValue"]>]> {
   let summary = "Softmax operator";
   let description = [{
     linalg.softmax computes a numerically stable version of softmax.


### PR DESCRIPTION
Tiling existed for the SoftMax op, but tile-and-fuse was not implemented. This adds the required interface function. It essentially creates a tile of iterations and a tile of the input, from a tile of the output. 

How SoftMax has been implemented makes it that tiling from the output is the same as that for tiling the "iteration domain": that domain corresponds to the input/output tensor, whereas once decomposed, linalg.generics with extra dimensions appear. The tensor dimension over which the reductions happen (in this invisible extra dimension) is considered a reduction iteration dimension, which indicates it shouldn't be tiled.