### PR TITLE
Revert "Allow to use the DenseElementsAttr get methods to be used with types …"

### DIFF
--- a/mlir/include/mlir/IR/BuiltinAttributes.h
+++ b/mlir/include/mlir/IR/BuiltinAttributes.h
@@ -112,9 +112,9 @@ public:
   static DenseElementsAttr get(ShapedType type, ArrayRef<Attribute> values);
 
   /// Constructs a dense integer elements attribute from an array of integer
-  /// or floating-point values. Each value is expected to be the same as the
-  /// storage bitwidth of the element type of 'type'. 'type' must be a vector or
-  /// tensor with static shape.
+  /// or floating-point values. Each value is expected to be the same bitwidth
+  /// of the element type of 'type'. 'type' must be a vector or tensor with
+  /// static shape.
   template <typename T,
             typename = std::enable_if_t<std::numeric_limits<T>::is_integer ||
                                         is_valid_cpp_fp_type<T>::value>>

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -1104,15 +1104,13 @@ bool DenseElementsAttr::isValidRawBuffer(ShapedType type,
 /// invariants that the templatized 'getValues' method cannot.
 static bool isValidIntOrFloat(Type type, int64_t dataEltSize, bool isInt,
                               bool isSigned) {
-  // Make sure that the data element size is the same as the type element
-  // storage width.
-  const size_t denseEltStorageBitWidth = getDenseElementStorageWidth(type);
-  const size_t dataSizeBitWidth = static_cast<size_t>(dataEltSize * CHAR_BIT);
-  if (denseEltStorageBitWidth != dataSizeBitWidth) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "expected dense element bit width " << denseEltStorageBitWidth
-               << " to match data size " << dataSizeBitWidth << " for type "
-               << type << "\n");
+  // Make sure that the data element size is the same as the type element width.
+  auto denseEltBitWidth = getDenseElementBitWidth(type);
+  auto dataSize = static_cast<size_t>(dataEltSize * CHAR_BIT);
+  if (denseEltBitWidth != dataSize) {
+    LLVM_DEBUG(llvm::dbgs() << "expected dense element bit width "
+                            << denseEltBitWidth << " to match data size "
+                            << dataSize << " for type " << type << "\n");
     return false;
   }
 

--- a/mlir/unittests/IR/AttributeTest.cpp
+++ b/mlir/unittests/IR/AttributeTest.cpp
@@ -570,26 +570,4 @@ TEST(NonSplattedDenseElementAttrTest, GetNonSplatRawDataI16) {
                 .getNonSplatRawData<uint16_t>(),
             expected);
 }
-
-TEST(NonSplattedDenseElementAttrTest, GetFromRawI7) {
-  constexpr std::size_t numberOfElements = 6;
-  static constexpr std::array<int8_t, numberOfElements> rawValues = {1, 2, 3,
-                                                                     4, 5, 6};
-
-  mlir::MLIRContext context;
-  mlir::OpBuilder b(&context);
-
-  auto values = mlir::DenseElementsAttr::get(
-      mlir::RankedTensorType::get({numberOfElements}, b.getIntegerType(7)),
-      ArrayRef<int8_t>(rawValues));
-  auto fromRaw = mlir::DenseIntOrFPElementsAttr::getFromRawBuffer(
-      values.getType(), values.getRawData());
-
-  EXPECT_EQ(values, fromRaw);
-  EXPECT_EQ(fromRaw.getElementType(), b.getIntegerType(7));
-  EXPECT_EQ(fromRaw.getNumElements(), numberOfElements);
-  for (auto [fr, e] : llvm::zip_equal(fromRaw.getValues<int8_t>(), rawValues)) {
-    EXPECT_EQ(fr, e);
-  }
-}
 } // namespace


### PR DESCRIPTION
Reverts Xilinx/llvm-project#568