### PR TITLE
[PDLL] Add `true` and `false` keywords

### DIFF
--- a/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
@@ -171,7 +171,9 @@ int Lexer::getNextChar() {
   }
 }
 
-StringRef Lexer::getCurrentInclude() const { return canonicalIncludeFileStack.back(); }
+StringRef Lexer::getCurrentInclude() const {
+  return canonicalIncludeFileStack.back();
+}
 
 bool Lexer::isLexingMainFile() const {
   return static_cast<int>(srcMgr.getMainFileID()) == curBufferID;
@@ -402,6 +404,8 @@ Token Lexer::lexIdentifier(const char *tokStart) {
                          .Case("log2", Token::log2)
                          .Case("exp2", Token::exp2)
                          .Case("math_abs", Token::abs)
+                         .Case("true", Token::kw_true)
+                         .Case("false", Token::kw_false)
                          .Default(Token::identifier);
   return Token(kind, str);
 }

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.h
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.h
@@ -71,6 +71,10 @@ public:
     kw_with,
     KW_END,
 
+    // Boolean keywords
+    kw_true,
+    kw_false,
+
     /// Punctuation.
     arrow,
     colon,

--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -344,6 +344,7 @@ private:
   FailureOr<ast::Expr *> parseMulDivModExpr();
   FailureOr<ast::Expr *> parseLogicalNotExpr();
   FailureOr<ast::Expr *> parseOtherExpr();
+  FailureOr<ast::Expr *> parseBoolExpr();
 
   /// Identifier expressions.
   FailureOr<ast::Expr *> parseArrayAttrExpr();
@@ -2301,6 +2302,10 @@ FailureOr<ast::Expr *> Parser::parseOtherExpr() {
   case Token::string_block:
     return emitError("expected expression. If you are trying to create an "
                      "ArrayAttr, use a space between `[` and `{`.");
+  case Token::kw_false:
+  case Token::kw_true:
+    lhsExpr = parseBoolExpr();
+    break;
   default:
     return emitError("expected expression");
   }
@@ -2576,6 +2581,16 @@ FailureOr<ast::Expr *> Parser::parseIntegerExpr() {
   consumeToken();
 
   auto allocated = copyStringWithNull(ctx, (Twine(value) + ":" + type).str());
+  return ast::AttributeExpr::create(ctx, loc, allocated);
+}
+
+FailureOr<ast::Expr *> Parser::parseBoolExpr() {
+  SMRange loc = curToken.getLoc();
+  const bool isTrue = curToken.is(Token::kw_true);
+  consumeToken();
+  const std::string boolAttrAsString = isTrue ? "true" : "false";
+
+  auto allocated = copyStringWithNull(ctx, boolAttrAsString);
   return ast::AttributeExpr::create(ctx, loc, allocated);
 }
 


### PR DESCRIPTION
This PR add the `true` and `false` keywords to PDLL.
They are parsed as `attr<"true">` and `attr<"false">`